### PR TITLE
Add initialization of the roc_decoder member variable in the DecHandle class constructor.

### DIFF
--- a/src/rocdecode/dec_handle.h
+++ b/src/rocdecode/dec_handle.h
@@ -32,7 +32,7 @@ THE SOFTWARE.
  */
 struct DecHandle {
 
-    explicit DecHandle() {};   //constructor
+    explicit DecHandle() : roc_decoder(std::make_shared<RocDecoder>()) {};   //constructor
     ~DecHandle() { clear_errors(); }
     std::shared_ptr<RocDecoder> roc_decoder;    // class instantiation
     bool no_error() { return error.empty(); }

--- a/src/rocdecode/roc_decoder.cpp
+++ b/src/rocdecode/roc_decoder.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 #include "../commons.h"
 #include "roc_decoder.h"
 
-RocDecoder::RocDecoder(int device_id, int num_devices):device_id_ {device_id}, num_devices_{num_devices} {
+RocDecoder::RocDecoder(int device_id):device_id_ {device_id}, num_devices_{0} {
   // todo:: 
     if (ROCDEC_SUCCESS != initHIP(device_id_)) {
         THROW("Failed to initilize the HIP");
@@ -32,6 +32,16 @@ RocDecoder::RocDecoder(int device_id, int num_devices):device_id_ {device_id}, n
 
 }
 
+ RocDecoder::~RocDecoder() {
+    // todo::
+    hipError_t hipStatus = hipSuccess;
+    if (hip_stream_) {
+        hipStatus = hipStreamDestroy(hip_stream_);
+        if (hipStatus != hipSuccess) {
+            ERR("ERROR: hipStreamDestroy failed! (" + TOSTR(hipStatus) + ")");
+        }
+    }
+ }
 rocDecStatus RocDecoder::getDecoderCaps(RocdecDecodeCaps *pdc) {
     // todo:: return appropriate decStatus if fails
     //vaQueryConfigProfiles

--- a/src/rocdecode/roc_decoder.h
+++ b/src/rocdecode/roc_decoder.h
@@ -36,7 +36,7 @@ THE SOFTWARE.
 
 class RocDecoder {
 public:
-    RocDecoder(int device_id, int num_devices);
+    RocDecoder(int device_id = 0);
     ~RocDecoder();
     rocDecStatus getDecoderCaps(RocdecDecodeCaps *pdc);
     rocDecStatus decodeFrame(RocdecPicParams *pPicParams);


### PR DESCRIPTION
- add missing initialization of the roc_decoder member variable in the DecHandle class constructor.
- remove num_devices as an input argument to the RocDecoder class. The RocDecdoer class has a member variable num_devices_ 
 which gets filled in the initHIP function called inside the RocDecoder constructor.
- fill the initial RocDecoder class destructor.