### PR TITLE
Fix a bug in GetVideoCodecString function where it didn't return the correct codec string

### DIFF
--- a/samples/videoDecode/videodecode.cpp
+++ b/samples/videoDecode/videodecode.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
     int pciBusID, pciDomainID, pciDeviceID;
 
     viddec.GetDeviceinfo(deviceName, gcnArchName, pciBusID, pciDomainID, pciDeviceID);
-    std::cout << "info: Using GPU device " << deviceId << deviceName << "[" << gcnArchName << "] on PCI bus " <<
+    std::cout << "info: Using GPU device " << deviceId << " - " << deviceName << "[" << gcnArchName << "] on PCI bus " <<
     std::setfill('0') << std::setw(2) << std::right << std::hex << pciBusID << ":" << std::setfill('0') << std::setw(2) <<
     std::right << std::hex << pciDomainID << "." << pciDeviceID << std::dec << std::endl;
     std::cout << "info: decoding started, please wait!" << std::endl;

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -91,11 +91,11 @@ static const char * GetVideoCodecString(rocDecVideoCodec eCodec) {
         { rocDecVideoCodec_MPEG2,     "MPEG-2"       },
         { rocDecVideoCodec_MPEG4,     "MPEG-4 (ASP)" },
         { rocDecVideoCodec_H264,      "AVC/H.264"    },
-        { rocDecVideoCodec_JPEG,      "M-JPEG"       },
         { rocDecVideoCodec_HEVC,      "H.265/HEVC"   },
+        { rocDecVideoCodec_AV1,       "AV1"          },
         { rocDecVideoCodec_VP8,       "VP8"          },
         { rocDecVideoCodec_VP9,       "VP9"          },
-        { rocDecVideoCodec_AV1,       "AV1"          },
+        { rocDecVideoCodec_JPEG,      "M-JPEG"       },
         { rocDecVideoCodec_NumCodecs, "Invalid"      },
     };
 


### PR DESCRIPTION
The order of enums in the aCodecName table should match the rocDecVideoCodec enums otherwise the GetVideoCodecString function returns the wrong string.