### PR TITLE
Create the correct render node names on MI300A/MI300X

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.h
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.h
@@ -55,6 +55,6 @@ private:
     VAConfigAttrib va_config_attrib_;
     VAConfigID va_config_id_;
     VAProfile va_profile_;
-    rocDecStatus InitVAAPI();
+    rocDecStatus InitVAAPI(std::string drm_node);
     rocDecStatus CreateDecoderConfig();
 };


### PR DESCRIPTION
Background info: Prior to MI300A/MI300X, there was only one renderDXXX per physical GPU. For example, if we have four GPUs (GPU0, GPU1, GPU2, and GPU3), then there are four renderDXXX defined as (renderD128, renderD129, renderD130, and renderD131), respectively.

However, MI300A/MI300X uses a different naming mechanism with 8 render names per physical device. Therefore, on MI300A/MI300X, we should use renderD128 for GPU0, renderD136 for GPU1, renderD144 for GPU2, and renderD152 for GPU3.

For rocDecode, we use the physical GPU device IDs (e.g., 0, 1, etc) to build a drm node name for creating a VAAPI display, therefore it is necessary to use the correct logic to build the drm node on MI300A/MI300X.
