### PR TITLE
Don't install dependencies in CI compile stage

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -20,7 +20,6 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 set -x
                 echo Build rocDecode - ${buildTypeDir}
                 cd ${project.paths.project_build_prefix}
-                python rocDecode-setup.py
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}
                 ${enableSCL}
                 cmake ${buildTypeArg} ../..


### PR DESCRIPTION
Installing the dependencies in the CI compile stage causes issues due to permissions, these dependencies should be accounted for in the CI system instead.