### PR TITLE
Add support to GetDecoderCaps to correctly return decoder caps for gfx arch names with a suffix

### DIFF
--- a/src/rocdecode/roc_decoder_caps.h
+++ b/src/rocdecode/roc_decoder_caps.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include <string>
 #include <unordered_map>
 #include <mutex>
+#include <algorithm>
 #include "../commons.h"
 #include "../../api/rocdecode.h"
 
@@ -55,7 +56,9 @@ public:
     }
     rocDecStatus GetDecoderCaps(std::string gcn_arch_name, RocdecDecodeCaps *pdc) {
         std::lock_guard<std::mutex> lock(mutex);
-        auto it = vcn_spec_table.find(gcn_arch_name);
+        std::size_t pos = gcn_arch_name.find_first_of(":");
+        std::string gcn_arch_name_base = (pos != std::string::npos) ? gcn_arch_name.substr(0, pos) : gcn_arch_name;
+        auto it = vcn_spec_table.find(gcn_arch_name_base);
         if (it != vcn_spec_table.end()) {
             const VcnCodecsSpec& vcn_spec = it->second;
             auto it1 = vcn_spec.codecs_spec.find(pdc->eCodecType);
@@ -84,7 +87,9 @@ public:
     }
     bool IsCodecConfigSupported(std::string gcn_arch_name, rocDecVideoCodec codec_type, rocDecVideoChromaFormat chroma_format, uint32_t bit_depth_minus8, rocDecVideoSurfaceFormat output_format) {
         std::lock_guard<std::mutex> lock(mutex);
-        auto it = vcn_spec_table.find(gcn_arch_name);
+        std::size_t pos = gcn_arch_name.find_first_of(":");
+        std::string gcn_arch_name_base = (pos != std::string::npos) ? gcn_arch_name.substr(0, pos) : gcn_arch_name;
+        auto it = vcn_spec_table.find(gcn_arch_name_base);
         if (it != vcn_spec_table.end()) {
             const VcnCodecsSpec& vcn_spec = it->second;
             auto it1 = vcn_spec.codecs_spec.find(codec_type);


### PR DESCRIPTION
Currently, we use the "gfx arch name" (e.g., gfx90a) to retrieve the decoder capabilities. However, some ASICs have a colon-separated suffix in their "gfx arch name" (e.g., gfx90a:sramecc+:xnack-). The VCN look-up table only contains the base "gfx arch name" without any colon. Therefore, we need to extract the base "gfx arch name" before searching the look-up table to handle the case where there is a colon-separated suffix in the "gfx arch name".