### PR TITLE
Fixed a regression introduced by PR#30.

### DIFF
--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -655,8 +655,7 @@ bool HEVCVideoParser::ParseFrameData(const uint8_t* p_stream, uint32_t frame_dat
                 }
 
                 default:
-                    ERR(STR("Error: Invalid NAL unit type"));
-                    return false;
+                    break;
             }
         }
 


### PR DESCRIPTION
We should not abort parsing when we see NAL unit types that we are not interested in. Instead, we should just ignore and continue.