### PR TITLE
Fixed the missing output picture issue on certain streams.

### DIFF
--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -2230,10 +2230,8 @@ int HEVCVideoParser::MarkOutputPictures() {
 
         if (!no_output_of_prior_pics_flag) {
             // Bump the remaining pictures
-            while (dpb_buffer_.num_needed_for_output) {
-                if (BumpPicFromDpb() != PARSER_OK) {
-                    return PARSER_FAIL;
-                }
+            if (FlushDpb() != PARSER_OK) {
+                return PARSER_FAIL;
             }
         }
 


### PR DESCRIPTION
When we hit an IRAP (Intra Random Access Point) picture and need to bump all remaining decoded pictures from DPB, call display callback immediately, instead of delaying the callback to the IRAP decode process.