### PR TITLE
Fixed corruptions in RASL (Random Access Skipped Leading) pictures of an associated CRA picture.

### DIFF
--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -307,6 +307,22 @@ int HEVCVideoParser::SendPicForDecode() {
         ref_idx++;
     }
 
+    for (i = 0; i < num_poc_st_foll_; i++) {
+        buf_idx = ref_pic_set_st_foll_[i]; // buffer index in DPB
+        pic_param_ptr->ref_frames[ref_idx].PicIdx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        pic_param_ptr->ref_frames[ref_idx].POC = dpb_buffer_.frame_buffer_list[buf_idx].pic_order_cnt;
+        pic_param_ptr->ref_frames[ref_idx].Flags = 0; // assume frame picture for now
+        ref_idx++;
+    }
+
+    for (i = 0; i < num_poc_lt_foll_; i++) {
+        buf_idx = ref_pic_set_lt_foll_[i]; // buffer index in DPB
+        pic_param_ptr->ref_frames[ref_idx].PicIdx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        pic_param_ptr->ref_frames[ref_idx].POC = dpb_buffer_.frame_buffer_list[buf_idx].pic_order_cnt;
+        pic_param_ptr->ref_frames[ref_idx].Flags = 0; // assume frame picture for now
+        ref_idx++;
+    }
+
     for (i = ref_idx; i < 15; i++) {
         pic_param_ptr->ref_frames[i].PicIdx = 0xFF;
     }


### PR DESCRIPTION
  - It appears that the root cause of the corruption is the loss of some reference info of the RASL pictures at VA-API driver level.
  - For reasons that are not documented in VA-API, or simply implementation limitations, the DPB buffer status when a CRA picture is decoded, needs to be sent to VA-API driver to the correct decoding of the associated RASL pictures. The info is stored in PocStFoll and PocLtFoll and is not needed for CRA picture decode, which is an intra picture. Without this info, the following RASL picture decode will run into problem even when its reference picture info is correctly specified.
  - Note this appears to be a VA-API specific issue because it did not occur on other platforms.