### PR TITLE
Added frame rate info report when it is available, from the parser.

### DIFF
--- a/src/parser/roc_video_parser.cpp
+++ b/src/parser/roc_video_parser.cpp
@@ -26,6 +26,8 @@ RocVideoParser::RocVideoParser() {
     pic_width_ = 0;
     pic_height_ = 0;
     new_sps_activated_ = false;
+    frame_rate_.numerator = 0;
+    frame_rate_.denominator = 0;
 }
 
 /**

--- a/src/parser/roc_video_parser.h
+++ b/src/parser/roc_video_parser.h
@@ -56,6 +56,11 @@ protected:
     uint32_t pic_height_;
     bool new_sps_activated_;
 
+    struct {
+        uint32_t numerator;
+        uint32_t denominator;
+    } frame_rate_;
+
     RocdecVideoFormat video_format_params_;
     RocdecSeiMessageInfo sei_message_info_params_;
     RocdecPicParams dec_pic_params_;

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -251,8 +251,11 @@ int RocVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
     input_video_info_str_.str("");
     input_video_info_str_.clear();
     input_video_info_str_ << "Input Video Information" << std::endl
-        << "\tCodec        : " << GetCodecFmtName(p_video_format->codec) << std::endl
-        << "\tSequence     : " << (p_video_format->progressive_sequence ? "Progressive" : "Interlaced") << std::endl
+        << "\tCodec        : " << GetCodecFmtName(p_video_format->codec) << std::endl;
+        if (p_video_format->frame_rate.numerator && p_video_format->frame_rate.denominator) {
+            input_video_info_str_ << "\tFrame rate   : " << p_video_format->frame_rate.numerator << "/" << p_video_format->frame_rate.denominator << " = " << 1.0 * p_video_format->frame_rate.numerator / p_video_format->frame_rate.denominator << " fps" << std::endl;
+        }
+    input_video_info_str_ << "\tSequence     : " << (p_video_format->progressive_sequence ? "Progressive" : "Interlaced") << std::endl
         << "\tCoded size   : [" << p_video_format->coded_width << ", " << p_video_format->coded_height << "]" << std::endl
         << "\tDisplay area : [" << p_video_format->display_area.left << ", " << p_video_format->display_area.top << ", "
             << p_video_format->display_area.right << ", " << p_video_format->display_area.bottom << "]" << std::endl


### PR DESCRIPTION
Note that frame info in the elementary stream is optional per spec.