### PR TITLE
added help for arguments in case user doesn't give any arguments

### DIFF
--- a/samples/videoDecode/videodecode.cpp
+++ b/samples/videoDecode/videodecode.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     Rect *p_crop_rect = nullptr;
     OutputSurfaceMemoryType mem_type = OUT_SURFACE_MEM_DEV_INTERNAL;        // set to internal
     // Parse command-line arguments
-    if(argc < 1) {
+    if(argc <= 1) {
         ShowHelpAndExit();
     }
     for (int i = 1; i < argc; i++) {

--- a/samples/videoDecodeFork/videodecodefork.cpp
+++ b/samples/videoDecodeFork/videodecodefork.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
     OutputSurfaceMemoryType mem_type = OUT_SURFACE_MEM_DEV_INTERNAL;        // set to internal
     bool b_force_zero_latency = false;
     // Parse command-line arguments
-    if(argc < 1) {
+    if(argc <= 1) {
         ShowHelpAndExit();
     }
     for (int i = 1; i < argc; i++) {

--- a/samples/videoDecodeMem/videodecodemem.cpp
+++ b/samples/videoDecodeMem/videodecodemem.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
     Rect *p_crop_rect = nullptr;
     OutputSurfaceMemoryType mem_type = OUT_SURFACE_MEM_DEV_INTERNAL;        // set to internal
     // Parse command-line arguments
-    if(argc < 1) {
+    if(argc <= 1) {
         ShowHelpAndExit();
     }
     for (int i = 1; i < argc; i++) {

--- a/samples/videoDecodeMultiFiles/videodecodemultifiles.cpp
+++ b/samples/videoDecodeMultiFiles/videodecodemultifiles.cpp
@@ -76,7 +76,7 @@ void ParseCommandLine(std::deque<FileInfo> *multi_file_data, int &device_id, boo
     std::string file_list_path;
 
     // Parse command-line arguments
-    if(argc < 1) {
+    if(argc <= 1) {
         ShowHelpAndExit();
     }
     for (int i = 1; i < argc; i++) {

--- a/samples/videoDecodePerf/videodecodeperf.cpp
+++ b/samples/videoDecodePerf/videodecodeperf.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
     OutputSurfaceMemoryType mem_type = OUT_SURFACE_MEM_DEV_INTERNAL;        // set to internal
     bool b_force_zero_latency = false;
     // Parse command-line arguments
-    if(argc < 1) {
+    if(argc <= 1) {
         ShowHelpAndExit();
     }
     for (int i = 1; i < argc; i++) {

--- a/samples/videoDecodeRGB/videodecrgb.cpp
+++ b/samples/videoDecodeRGB/videodecrgb.cpp
@@ -166,7 +166,7 @@ int main(int argc, char **argv) {
     int rgb_width;
 
     // Parse command-line arguments
-    if(argc < 1) {
+    if(argc <= 1) {
         ShowHelpAndExit();
     }
     for (int i = 1; i < argc; i++) {


### PR DESCRIPTION
The samples would previously return errors if no arguments were given. The -h option had to be specified for help in what arguments to put. I made it so that if the user doesn't input any arguments, the help function gets called.