### PR TITLE
Fixed a bug in destroy data buffer function in VAAPI layer.

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -175,15 +175,19 @@ rocDecStatus VaapiVideoDecoder::CreateContext() {
 rocDecStatus VaapiVideoDecoder::DestroyDataBuffers() {
     if (pic_params_buf_id_) {
         CHECK_VAAPI(vaDestroyBuffer(va_display_, pic_params_buf_id_));
+        pic_params_buf_id_ = 0;
     }
     if (iq_matrix_buf_id_) {
         CHECK_VAAPI(vaDestroyBuffer(va_display_, iq_matrix_buf_id_));
+        iq_matrix_buf_id_ = 0;
     }
     if (slice_params_buf_id_) {
         CHECK_VAAPI(vaDestroyBuffer(va_display_, slice_params_buf_id_));
+        slice_params_buf_id_ = 0;
     }
     if (slice_data_buf_id_) {
         CHECK_VAAPI(vaDestroyBuffer(va_display_, slice_data_buf_id_));
+        slice_data_buf_id_ = 0;
     }
     return ROCDEC_SUCCESS;
 }


### PR DESCRIPTION
  - We have to clear the buffer id after destroying it. Without this clearing, we will encounter VAAPI buffer destroy failure on certain conformance streams where scaling list is signalled dynamically. In this case, we create different number of data buffers on different frames. If we do not clear the buffer id when destroying it, a dummy scaling list buffer id will have the same value as another buffer, resulting double destroy.
  - With this fix, the dynamic scaling list conformance streams now pass.