### PR TITLE
Bug Fix - when setting env variable HIP_VISIBLE_DEVICES

### DIFF
--- a/samples/videoDecodeFork/videodecodefork.cpp
+++ b/samples/videoDecodeFork/videodecodefork.cpp
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
         std::string gcn_arch_name_base = (pos != std::string::npos) ? gcn_arch_name.substr(0, pos) : gcn_arch_name;
 
         // gfx90a has two GCDs as two separate devices 
-        if (!gcn_arch_name_base.compare("gfx90a")) {
+        if (!gcn_arch_name_base.compare("gfx90a") && num_devices > 1) {
             sd = 1;
         }
 

--- a/samples/videoDecodePerf/videodecodeperf.cpp
+++ b/samples/videoDecodePerf/videodecodeperf.cpp
@@ -163,7 +163,7 @@ int main(int argc, char **argv) {
         std::string gcn_arch_name_base = (pos != std::string::npos) ? gcn_arch_name.substr(0, pos) : gcn_arch_name;
 
         // gfx90a has two GCDs as two separate devices 
-        if (!gcn_arch_name_base.compare("gfx90a")) {
+        if (!gcn_arch_name_base.compare("gfx90a") && num_devices > 1) {
             sd = 1;
         }
 


### PR DESCRIPTION
This adds a check to see if all GPUs can be used or if a particular GPU is chosed by user by setting "export HIP_VISIBLE_DEVICES=0"