### PR TITLE
Remove unnecessary device id check

### DIFF
--- a/src/rocdecode/roc_decoder.cpp
+++ b/src/rocdecode/roc_decoder.cpp
@@ -135,10 +135,6 @@ rocDecStatus RocDecoder::InitHIP(int device_id) {
         ERR("ERROR: didn't find any GPU!");
         return ROCDEC_DEVICE_INVALID;
     }
-    if (device_id >= num_devices_) {
-        ERR("ERROR: the requested device_id is not found! ");
-        return ROCDEC_DEVICE_INVALID;
-    }
     CHECK_HIP(hipSetDevice(device_id));
     CHECK_HIP(hipGetDeviceProperties(&hip_dev_prop_, device_id));
 

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -1073,10 +1073,6 @@ bool RocVideoDecoder::InitHIP(int device_id) {
         std::cerr << "ERROR: didn't find any GPU!" << std::endl;
         return false;
     }
-    if (device_id >= num_devices_) {
-        std::cerr << "ERROR: the requested device_id is not found! " << std::endl;
-        return false;
-    }
     HIP_API_CALL(hipSetDevice(device_id));
     HIP_API_CALL(hipGetDeviceProperties(&hip_dev_prop_, device_id));
     HIP_API_CALL(hipStreamCreate(&hip_stream_));


### PR DESCRIPTION
This PR removes the unnecessary device id check (i.e., device_id >= num_devices_). This check is not needed because the next API call is hipSetDevice which properly checks the device_id to be valid. Also, this extra device_id check is not correct when the HIP_VISIBLE_DEVICES is present. This environment variable exposes the device indices to HIP applications. For example in a system with 4 GPUs, the HIP_VISIBLE_DEVICES="0,3" exposes the first and fourth devices to the application. In this case, the num_devices_ is 2, and the dvice_id of 3 is valid and can be used for hipSetDevice. However, keeping the unnecessary if condition (i.e., if (device_id >= num_devices_)) in our code won't work so it needs to be removed.
