### PR TITLE
Use custom rocm-docs-core footer, header, and stylesheets for doxysphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,55 +11,65 @@ rocDecode is a high performance video decode SDK for AMD GPUs. rocDecode API let
 ## Prerequisites
 
 * Linux distribution
-  + Ubuntu - `20.04` / `22.04`
-  + RHEL - `8` / `9`
-  + SLES - `15-SP4`
+    * Ubuntu - `20.04` / `22.04`
+    * RHEL - `8` / `9`
+    * SLES - `15-SP4`
 
 * [ROCm supported hardware](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html)
-  + **NOTE:** `gfx908` or higher required
+    * **NOTE:** `gfx908` or higher required
 
 * Install ROCm `6.1.0` or later with [amdgpu-install](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/amdgpu-install.html) with `--usecase=multimediasdk,rocm --no-32`
-  + **NOTE:** To install rocdecode with minimum requirements follow instructions [here](https://github.com/ROCm/rocDecode/wiki#how-can-i-install-rocdecode-runtime-with-minimum-requirements)
+    * **NOTE:** To install rocdecode with minimum requirements follow instructions [here](https://github.com/ROCm/rocDecode/wiki#how-can-i-install-rocdecode-runtime-with-minimum-requirements)
 
 ### To build from source
 
 * CMake `3.5` or later
+
 ```shell
 sudo apt install cmake
 ```
 
 * [pkg-config](https://en.wikipedia.org/wiki/Pkg-config)
+
 ```shell
 sudo apt install pkg-config
 ```
 
 * [FFMPEG](https://ffmpeg.org/about.html) runtime and headers - for tests and samples
+
 ```shell
 sudo apt install ffmpeg libavcodec-dev libavformat-dev libavutil-dev
 ```
 
-**NOTE:** 
+**NOTE:**
+
 * All package install shown with `apt` package manager, use appropriate package manager depending on the OS.
 
 * Ubuntu 22.04 - Install `libstdc++-12-dev`
+
 ```shell
 sudo apt install libstdc++-12-dev
 ```
+
 #### Prerequisites setup script for Linux
+
 For the convenience of the developer, we provide the setup script [rocDecode-setup.py](rocDecode-setup.py) which will install all the dependencies required by this project.
 
 **Usage:**
+
 ```shell
   python rocDecode-setup.py  --rocm_path [ ROCm Installation Path - optional (default:/opt/rocm)]
                              --developer [ Setup Developer Options - optional (default:ON) [options:ON/OFF]]
 ```
+
 **NOTE:** This script only needs to be executed once.
 
 ## Build and install instructions
 
 ### Package install
 
-Install rocDecode runtime, development, and test packages. 
+Install rocDecode runtime, development, and test packages.
+
 * Runtime package - `rocdecode` only provides the rocdecode library `librocdecode.so`
 * Development package - `rocdecode-dev`/`rocdecode-devel` provides the library, header files, and samples
 * Test package - `rocdecode-test` provides ctest to verify installation
@@ -67,14 +77,19 @@ Install rocDecode runtime, development, and test packages.
 **NOTE:** Package install will auto install all dependencies.
 
 #### Ubuntu
+
 ```shell
 sudo apt install rocdecode rocdecode-dev rocdecode-test
 ```
+
 #### RHEL
+
 ```shell
 sudo yum install rocdecode rocdecode-devel rocdecode-test
 ```
+
 #### SLES
+
 ```shell
 sudo zypper install rocdecode rocdecode-devel rocdecode-test
 ```
@@ -95,6 +110,7 @@ sudo make install
   ```shell
   make test
   ```
+
   **NOTE:** run tests with verbose option `make test ARGS="-VV"`
 
 * make package
@@ -141,11 +157,13 @@ The tool provides a few samples to decode videos [here](samples/). Please refer 
 
 * [FFMPEG](https://ffmpeg.org/about.html) - required to run sample applications & make test
 
-  * On `Ubuntu`
+    * On `Ubuntu`
+
   ```shell
   sudo apt install ffmpeg libavcodec-dev libavformat-dev libavutil-dev
   ```
-  * On `RHEL`/`SLES` - install ffmpeg development packages manually or use `rocDecode-setup.py` script
+  
+    * On `RHEL`/`SLES` - install ffmpeg development packages manually or use `rocDecode-setup.py` script
 
 ## Docker
 
@@ -156,6 +174,7 @@ Docker files to build rocDecode containers are available [here](docker/)
 Run the steps below to build documentation locally.
 
 * Sphinx
+
 ```shell
 cd docs
 pip3 install -r sphinx/requirements.txt
@@ -163,6 +182,7 @@ python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
 ```
 
 * Doxygen
+
 ```shell
 doxygen .Doxyfile
 ```
@@ -170,11 +190,11 @@ doxygen .Doxyfile
 ## Tested configurations
 
 * Linux distribution
-  * Ubuntu - `20.04` / `22.04`
-  * RHEL - `8` / `9`
-  * SLES - `15-SP4`
+    * Ubuntu - `20.04` / `22.04`
+    * RHEL - `8` / `9`
+    * SLES - `15-SP4`
 * ROCm:
-  * rocm-core - `5.6.1.50601-93`
-  * amdgpu-core - `1:5.6.50601-1649308`
+    * rocm-core - `5.6.1.50601-93`
+    * amdgpu-core - `1:5.6.50601-1649308`
 * FFMPEG - `4.2.7` / `4.4.2-0`
 * rocDecode Setup Script - `V1.4`

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -1317,7 +1317,7 @@ HTML_FILE_EXTENSION    = .html
 # of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_HEADER            =
+HTML_HEADER            = ../_doxygen/header.html
 
 # The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
 # generated HTML page. If the tag is left blank doxygen will generate a standard
@@ -1327,7 +1327,7 @@ HTML_HEADER            =
 # that doxygen normally uses.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_FOOTER            =
+HTML_FOOTER            = ../_doxygen/footer.html
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading style
 # sheet that is used by each HTML page. It can be used to fine-tune the look of
@@ -1339,7 +1339,7 @@ HTML_FOOTER            =
 # obsolete.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_STYLESHEET        =
+HTML_STYLESHEET        = ../_doxygen/stylesheet.css
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # cascading style sheets that are included after the standard style sheets
@@ -1357,7 +1357,7 @@ HTML_STYLESHEET        =
 # documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = ../_doxygen/extra_stylesheet.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note


### PR DESCRIPTION
Removes doxygen header and footer

Adds custom styles as well as better styling for dark mode

Also fixes some markdownlint violations in README

Closes https://github.com/ROCm/rocm-docs-core/issues/605