### PR TITLE
Experimental PR. Do not merge. Attempted to address the regression in HEVC conformance test from PR#195. 

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -327,6 +327,11 @@ rocDecStatus VaapiVideoDecoder::ExportSurface(int pic_idx, VADRMPRIMESurfaceDesc
     if (pic_idx >= va_surface_ids_.size()) {
         return ROCDEC_INVALID_PARAMETER;
     }
+    VASurfaceStatus surface_status;
+    CHECK_VAAPI(vaQuerySurfaceStatus(va_display_, va_surface_ids_[pic_idx], &surface_status));
+    if (surface_status != VASurfaceReady) {
+        CHECK_VAAPI(vaSyncSurface(va_display_, va_surface_ids_[pic_idx]));
+    }
     CHECK_VAAPI(vaExportSurfaceHandle(va_display_, va_surface_ids_[pic_idx],
                 VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2,
                 VA_EXPORT_SURFACE_READ_ONLY |


### PR DESCRIPTION
 - We query decode status first before calling vaSyncSurface().