### PR TITLE
Samples - Clean up and bug fixes

### DIFF
--- a/samples/videoDecode/videodecode.cpp
+++ b/samples/videoDecode/videodecode.cpp
@@ -228,8 +228,8 @@ int main(int argc, char **argv) {
                 viddec.ReleaseFrame(pts);
             }
             auto end_time = std::chrono::high_resolution_clock::now();
-            auto time_per_frame = std::chrono::duration<double, std::milli>(end_time - start_time).count();
-            total_dec_time += time_per_frame;
+            auto time_per_decode = std::chrono::duration<double, std::milli>(end_time - start_time).count();
+            total_dec_time += time_per_decode;
             n_frame += n_frame_returned;
         } while (n_video_bytes);
         

--- a/samples/videoDecodeMem/videodecodemem.cpp
+++ b/samples/videoDecodeMem/videodecodemem.cpp
@@ -42,9 +42,17 @@ public:
     FileStreamProvider(const char *input_file_path) {
         fp_in_.open(input_file_path, std::ifstream::in | std::ifstream::binary);
         if (!fp_in_) {
-            std::cout << "Unable to open input file: " << input_file_path << std::endl;
-            return;
+            std::cerr << "Unable to open input file: " << input_file_path << std::endl;
+            exit(-1);
         }
+        fp_in_.seekg (0, fp_in_.end);
+        int length = fp_in_.tellg();
+        fp_in_.seekg (0, fp_in_.beg);
+        if (length > (100 * 1024 * 1024)) { // avioc_buffer_size = 100 * 1024 * 1024 in video_demuxer.h
+            std::cerr << "This app supports only file sizes upto 100MB! Please use a smaller file." << std::endl;
+            exit(-1);
+        }
+
     }
     ~FileStreamProvider() {
         fp_in_.close();

--- a/samples/videoDecodePerf/videodecodeperf.cpp
+++ b/samples/videoDecodePerf/videodecodeperf.cpp
@@ -50,10 +50,10 @@ void DecProc(RocVideoDecoder *p_dec, VideoDemuxer *demuxer, int *pn_frame, doubl
     } while (n_video_bytes);
 
     auto end_time = std::chrono::high_resolution_clock::now();
-    auto time_per_frame = std::chrono::duration<double, std::milli>(end_time - start_time).count();
+    auto time_per_decode = std::chrono::duration<double, std::milli>(end_time - start_time).count();
 
     // Calculate average decoding time
-    total_dec_time = time_per_frame;
+    total_dec_time = time_per_decode;
     double average_decoding_time = total_dec_time / n_frame;
     double n_fps = 1000 / average_decoding_time;
     *pn_fps = n_fps;

--- a/utils/video_demuxer.h
+++ b/utils/video_demuxer.h
@@ -233,7 +233,7 @@ AVFormatContext *VideoDemuxer::CreateFmtContextUtil(StreamProvider *stream_provi
         return nullptr;
     }
     uint8_t *avioc_buffer = nullptr;
-    int avioc_buffer_size = 10 * 1024 * 1024;
+    int avioc_buffer_size = 100 * 1024 * 1024;
     avioc_buffer = (uint8_t *)av_malloc(avioc_buffer_size);
     if (!avioc_buffer) {
         std::cerr << "ERROR: av_malloc failed!" << std::endl;


### PR DESCRIPTION
- Moves location of input file print
- Corrects timing/FPS issues seen by vaSyncSurface removal.
- Address comment [here](https://github.com/ROCm/rocDecode/pull/199#discussion_r1465640586)
- Fixes incorrect error seen by @paveltc for videoDecodeMem app (rocDecoder: not iniiatlized) by increasing file size to 100MB. This is required because the sample app holds the entire file in buffer

@AryanSalmanpour ready to be merged
