### PR TITLE
fixed syntax error in videodecodefork.cpp, was missing a semicolon at…

### DIFF
--- a/samples/videoDecodeFork/videodecodefork.cpp
+++ b/samples/videoDecodeFork/videodecodefork.cpp
@@ -58,7 +58,7 @@ void ShowHelpAndExit(const char *option = NULL) {
     << "-i Input File Path - required" << std::endl
     << "-f Number of forks (>= 1) - optional; default: 4" << std::endl
     << "-d Device ID (>= 0)  - optional; default: 0" << std::endl
-    << "-z force_zero_latency (force_zero_latency, Decoded frames will be flushed out for display immediately); optional;" << std::endl
+    << "-z force_zero_latency (force_zero_latency, Decoded frames will be flushed out for display immediately); optional;" << std::endl;
     exit(0);
 }
 


### PR DESCRIPTION
… the end of line 61.