### PR TITLE
Fix a bug in VideoDecodeRGB for syncing between main and worker threads

### DIFF
--- a/samples/videoDecodeRGB/videodecrgb.cpp
+++ b/samples/videoDecodeRGB/videodecrgb.cpp
@@ -203,10 +203,9 @@ void ColorSpaceConversionThread(std::atomic<bool>& continue_processing, bool con
                 viddec.SaveFrameToFile(output_file_path, frame, *surf_info);
         }
 
-        //current_frame_index = 1 - current_frame_index;
+        cv[current_frame_index].notify_one();
         current_frame_index = (current_frame_index + 1) % frame_buffers_size;
 
-        cv[current_frame_index].notify_one();
     }
 }
 


### PR DESCRIPTION
The worker thread should notify the main thread that the buffer is done before updating the current_buffer_index. 