### PR TITLE
Disable AVC codec support by default for 6.1 release

### DIFF
--- a/src/parser/rocparser_api.cpp
+++ b/src/parser/rocparser_api.cpp
@@ -33,6 +33,14 @@ rocDecCreateVideoParser(RocdecVideoParser *parser_handle, RocdecParserParams *pa
     if (parser_handle == nullptr || parser_params == nullptr) {
         return ROCDEC_INVALID_PARAMETER;
     }
+
+    const char *is_avc_enabled = std::getenv("ROCDECODE_ENABLE_AVC");
+    if (parser_params->codec_type != rocDecVideoCodec_HEVC &&
+        (parser_params->codec_type == rocDecVideoCodec_AVC && (is_avc_enabled == nullptr || std::string(is_avc_enabled) != "1"))) {
+        ERR("The current version of rocDecode officially supports only the H.265 (HEVC) codec.");
+        return ROCDEC_NOT_IMPLEMENTED;
+    }
+
     RocdecVideoParser handle = nullptr;
     try {
         handle = new RocParserHandle(parser_params);


### PR DESCRIPTION
This PR disables the AVC support by default. This is required for the 6.1 release. The AVC support can be enabled using an environment variable (ROCDECODE_ENABLE_AVC=1) to continue AVC development and performance tuning. This environment variable does not affect HEVC.

**Example output without  ROCDECODE_ENABLE_AVC**
`./videodecode -i ../../../data/videos/AMD_driving_virtual_20-H264.mp4 `
info: Input file: AMD_driving_virtual_20-H264.mp4
[ERR]  {rocDecCreateVideoParser}  The current version of rocDecode officially supports only the H.265 (HEVC) codec.
 { RocVideoDecoder } rocDecCreateVideoParser(&rocdec_parser_, &parser_params) returned **ROCDEC_NOT_IMPLEMENTED** at /home/user1/work/rocDecode/utils/rocvideodecode/roc_video_dec.cpp:50

**Example output with  ROCDECODE_ENABLE_AVC=1**
`ROCDECODE_ENABLE_AVC=1 ./videodecode -i ../../../data/videos/AMD_driving_virtual_20-H264.mp4` 
info: Input file: AMD_driving_virtual_20-H264.mp4
info: Using GPU device 0 - AMD Radeon RX 6750 XT[gfx1031] on PCI bus 0b:00.0
info: decoding started, please wait!
Input Video Information
        Codec        : AVC/H.264
        Sequence     : Progressive
        Coded size   : [2048, 1024]
        Display area : [0, 0, 2048, 1024]
        Chroma       : YUV 420
        Bit depth    : 8
Video Decoding Params:
        Num Surfaces : 6
        Crop         : [0, 0, 0, 0]
        Resize       : 2048x1024

info: Total frame decoded: 601
info: avg decoding time per frame: 2.08464 ms
info: avg FPS: 479.698
