### PR TITLE
Sample Bug Fix - Batch sync issue

### DIFF
--- a/samples/videoDecodeBatch/videodecodebatch.cpp
+++ b/samples/videoDecodeBatch/videodecodebatch.cpp
@@ -345,7 +345,6 @@ int main(int argc, char **argv) {
         }
 
         std::mutex mutex;
-        std::condition_variable cond_var;
 
         for (int j = 0; j < num_files; j++) {
             int thread_idx = j % n_thread;


### PR DESCRIPTION
Fixes the sync issue noticed on MI250X for batch sample. Tested on Lockhart with HEVC/1080 directory with t=1,2,4.
@AryanSalmanpour  could you please test again on your Navi31?