### PR TITLE
librocdecode optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ if(HIP_FOUND AND Libva_FOUND)
   include_directories(api src/rocdecode src/parser src/rocdecode/vaapi)
   # source files
   file(GLOB_RECURSE SOURCES "./src/*.cpp")
+  list(APPEND SOURCES utils/rocvideodecode/roc_video_dec.cpp)
   # rocdecode.so
   add_library(${PROJECT_NAME} SHARED ${SOURCES})
 

--- a/samples/videoDecode/CMakeLists.txt
+++ b/samples/videoDecode/CMakeLists.txt
@@ -77,7 +77,7 @@ if(HIP_FOUND AND FFMPEG_FOUND AND ROCDECODE_FOUND)
     include_directories (${ROCDECODE_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${ROCDECODE_LIBRARY})
     # sample app exe
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecode.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp)
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecode.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
     target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})

--- a/samples/videoDecodeBatch/CMakeLists.txt
+++ b/samples/videoDecodeBatch/CMakeLists.txt
@@ -82,7 +82,7 @@ if(HIP_FOUND AND FFMPEG_FOUND AND ROCDECODE_FOUND)
     find_package(Threads REQUIRED)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
 
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodebatch.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp)
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodebatch.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
     target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})

--- a/samples/videoDecodeMem/CMakeLists.txt
+++ b/samples/videoDecodeMem/CMakeLists.txt
@@ -77,7 +77,7 @@ if(HIP_FOUND AND FFMPEG_FOUND AND ROCDECODE_FOUND)
     include_directories (${ROCDECODE_INCLUDE_DIR})
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${ROCDECODE_LIBRARY})
     # sample app exe
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodemem.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp)
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodemem.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
     target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})

--- a/samples/videoDecodeMultiFiles/CMakeLists.txt
+++ b/samples/videoDecodeMultiFiles/CMakeLists.txt
@@ -77,7 +77,7 @@ if(HIP_FOUND AND FFMPEG_FOUND AND ROCDECODE_FOUND)
     include_directories (${ROCDECODE_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${ROCDECODE_LIBRARY})
     # sample app exe
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodemultifiles.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp)
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodemultifiles.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
     target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})

--- a/samples/videoDecodePerf/CMakeLists.txt
+++ b/samples/videoDecodePerf/CMakeLists.txt
@@ -81,7 +81,7 @@ if(HIP_FOUND AND FFMPEG_FOUND AND ROCDECODE_FOUND AND Threads_FOUND)
     find_package(Threads REQUIRED)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
     # sample app exe
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodeperf.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp)
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodeperf.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
     target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})

--- a/samples/videoDecodeRGB/CMakeLists.txt
+++ b/samples/videoDecodeRGB/CMakeLists.txt
@@ -86,7 +86,6 @@ if(HIP_FOUND AND FFMPEG_FOUND AND ROCDECODE_FOUND)
     # sample app exe
     list(APPEND SOURCES ${PROJECT_SOURCE_DIR} 
                         videodecrgb.cpp 
-                        ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp 
                         ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/colorspace_kernels.cpp
                         ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/resize_kernels.cpp)
 


### PR DESCRIPTION
In the current rocdecode installation step, we copy four header files into `/opt/rocm/include/rocdecode`. These are `rocdecode.h  rocparser.h  roc_video_dec.h  video_demuxer.h`. 

- `video_demuxer.h` is a header-only file with the implementation inside. 

- `rocdecode.h`  and `rocparser.h` (i.e., core rocdecode APIs) is implemented inside the `librocdecode.so` , which is installed into `/opt/rocm/lib/`

-  `roc_video_dec.h` implementation is not included inside the `librocdecode.so` and it is implemented inside the `roc_video_dec.cpp` , which is copied into `/opt/rocm/share/rocdecode/utils/rocvideodecode/`

In the current design, the users of rocdecode need to link with `librocdecode.so` as well as explicitly compile `roc_video_dec.cpp` with their apps to use these APIs/functions defined in these headers.

This PR proposes to include the implementation of the `roc_video_dec.h` inside the `librocdecode.so` to make it easier for end-users to use `roc_video_dec.h`  without needing to explicitly add the `roc_video_dec.cpp` to their apps for compilation.