### PR TITLE
Add support for detecting visible devices before  initializing va-api

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.h
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include <string>
 #include <fcntl.h>
 #include <unistd.h>
+#include <cstring>
 #include <va/va.h>
 #include <va/va_drm.h>
 #include <va/va_drmcommon.h>
@@ -76,4 +77,5 @@ private:
     rocDecStatus CreateSurfaces();
     rocDecStatus CreateContext();
     rocDecStatus DestroyDataBuffers();
+    void GetVisibleDevices(std::vector<int>& visible_devices);
 };


### PR DESCRIPTION
This PR supports creating the correct DRM node during va-api initialization if the HIP_VISIBLE_DEVICES is defined.

Background: Users can use the HIP_VISIBLE_DEVICES environment variable to enable specific devices in a multi-GPU system. Currently, this variable only applies to the HIP/ROCm SW stack and does not affect the multimedia SW stack (such as VA-API/Mesa). When initializing the VA-API stack, special handling is required to handle this environment variable since the rocDecode library uses both multimedia and compute SW stacks.

When the "HIP_VISIBLE_DEVICES" environment variable is defined, this PR ensures that the correct drm node is used for the initialization of the va-api. For example, If we consider a system with four GPUs, and "HIP_VISIBLE_DEVICES=2" is used, it will disable three GPUs for the HIP devices (i.e., device ids 0, 1, 3), leaving only the third physical device enabled on the ROCm stack. In this case, the only visible device on the system (the third physical device) will be presented as device ID 0 for the HIP stack. Therefore, to initialize the va-api stack, renderD130, which is the actual third physical device, should be used instead of renderD128. 