### PR TITLE
LibVA Updates - Support Public Version

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -16,6 +16,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
                 make -j\$(nproc)
                 sudo make install
                 sudo make package
+                objdump -x /opt/rocm/lib/librocdecode.so | grep NEEDED
                 ldd -v /opt/rocm/lib/librocdecode.so
                 """
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ Documentation for rocDecode is available at
 ### Changes
 
 * Dependencies - Updates to core dependencies
+* LibVA Headers - Use public headers
 
 ### Fixes
 
-* 
+* Package deps
 
 ### Tested configurations
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,15 +191,15 @@ if(HIP_FOUND AND Libva_FOUND)
   string(REGEX MATCH "22.04" UBUNTU_22_FOUND ${OS_RELEASE})
 
   # Set the dependent packages
-  set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva-amdgpu-drm2, libdrm-amdgpu1, mesa-amdgpu-va-drivers")
-  set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva-amdgpu, libdrm-amdgpu, mesa-amdgpu-dri-drivers")
+  set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva2 mesa-amdgpu-va-drivers")
+  set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva, mesa-amdgpu-dri-drivers")
   # Set the dev dependent packages
-  set(rocDecode_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-amdgpu-dev, pkg-config, ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev")
+  set(rocDecode_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-dev, pkg-config, ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev")
   if(UBUNTU_22_FOUND)
     set(rocDecode_DEBIAN_DEV_PACKAGE_LIST "${rocDecode_DEBIAN_DEV_PACKAGE_LIST}, libstdc++-12-dev")
   endif()
   # TBD - RPM packages need Fusion Packages - "ffmpeg, libavcodec-devel, libavformat-devel, libavutil-devel"
-  set(rocDecode_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, libva-amdgpu-devel, pkg-config")
+  set(rocDecode_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, libva-devel, pkg-config")
   
   # '%{?dist}' breaks manual builds on debian systems due to empty Provides
   execute_process(
@@ -325,6 +325,6 @@ else()
     message(FATAL_ERROR "-- ERROR!: HIP Not Found! - please install rocm-hip-runtime-dev!")
   endif()
   if(NOT Libva_FOUND)
-    message(FATAL_ERROR "-- ERROR!: libva Not Found - please install libva-amdgpu-dev/libva-amdgpu-devel!")
+    message(FATAL_ERROR "-- ERROR!: libva Not Found - please install libva-dev/libva-devel!")
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,9 +190,9 @@ if(HIP_FOUND AND Libva_FOUND)
   file(READ "/etc/os-release" OS_RELEASE)
   string(REGEX MATCH "22.04" UBUNTU_22_FOUND ${OS_RELEASE})
 
-  # Set the dependent packages
-  set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva2 mesa-amdgpu-va-drivers")
-  set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva, mesa-amdgpu-dri-drivers")
+  # Set the dependent packages - TBD: mesa-amdgpu-va-drivers should bring libdrm-amdgpu, but unavailable on RPM
+  set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva2, libdrm-amdgpu1, mesa-amdgpu-va-drivers")
+  set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva, libdrm-amdgpu, mesa-amdgpu-dri-drivers")
   # Set the dev dependent packages
   set(rocDecode_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-dev, pkg-config, ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev")
   if(UBUNTU_22_FOUND)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ access the video decoding features available on your GPU.
   sudo apt install libva-dev mesa-amdgpu-va-drivers
   ```
 > [!NOTE]
-> RPM Packages for `RHEL`/`SLES` - `libva-devel mesa-amdgpu-dri-drivers`
+> RPM Packages for `RHEL`/`SLES` - `libva-devel libdrm-amdgpu mesa-amdgpu-dri-drivers`
 
 * CMake `3.5` or later
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ access the video decoding features available on your GPU.
 
 * AMD multimedia packages
   ```shell
-  sudo apt install libva-amdgpu-dev libdrm-amdgpu1 mesa-amdgpu-va-drivers
+  sudo apt install libva-dev mesa-amdgpu-va-drivers
   ```
 > [!NOTE]
-> RPM Packages for `RHEL`/`SLES` - `libva-amdgpu-devel libdrm-amdgpu mesa-amdgpu-dri-drivers`
+> RPM Packages for `RHEL`/`SLES` - `libva-devel mesa-amdgpu-dri-drivers`
 
 * CMake `3.5` or later
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,19 @@ access the video decoding features available on your GPU.
 > [!IMPORTANT]
 > `sudo amdgpu-install --usecase=rocm`
 
-* AMD multimedia packages
+* [Video Acceleration API](https://en.wikipedia.org/wiki/Video_Acceleration_API) Version `1.5.0`+ - `Libva` is an implementation for VA-API
   ```shell
-  sudo apt install libva-dev mesa-amdgpu-va-drivers
+  sudo apt install libva-dev
   ```
 > [!NOTE]
-> RPM Packages for `RHEL`/`SLES` - `libva-devel libdrm-amdgpu mesa-amdgpu-dri-drivers`
+> RPM Packages for `RHEL`/`SLES` - `libva-devel`
+
+* AMD VA Drivers
+  ```shell
+  sudo apt install mesa-amdgpu-va-drivers
+  ```
+> [!NOTE]
+> RPM Packages for `RHEL`/`SLES` - `libdrm-amdgpu mesa-amdgpu-dri-drivers`
 
 * CMake `3.5` or later
 

--- a/README.md
+++ b/README.md
@@ -229,4 +229,4 @@ page.
   * rocm-core - `6.1.0.60100-64`
   * amdgpu-core - `1:6.1.60100-1741643`
 * FFmpeg - `4.2.7` / `4.4.2-0`
-* rocDecode Setup Script - `V1.7.1`
+* rocDecode Setup Script - `V1.7.2`

--- a/cmake/FindLibva.cmake
+++ b/cmake/FindLibva.cmake
@@ -30,6 +30,25 @@ find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBR
 mark_as_advanced(LIBVA_INCLUDE_DIR LIBVA_LIBRARY LIBVA_DRM_LIBRARY)
 
 if(Libva_FOUND)
+  # Find VA Version
+  file(READ "${LIBVA_INCLUDE_DIR}/va/va_version.h" VA_VERSION_FILE)
+  string(REGEX MATCH "VA_MAJOR_VERSION    ([0-9]*)" _ ${VA_VERSION_FILE})
+  set(va_ver_major ${CMAKE_MATCH_1})
+  string(REGEX MATCH "VA_MINOR_VERSION    ([0-9]*)" _ ${VA_VERSION_FILE})
+  set(va_ver_minor ${CMAKE_MATCH_1})
+  string(REGEX MATCH "VA_MICRO_VERSION    ([0-9]*)" _ ${VA_VERSION_FILE})
+  set(va_ver_micro ${CMAKE_MATCH_1})
+  message("-- ${White}Found Libva Version: ${va_ver_major}.${va_ver_minor}.${va_ver_micro}${ColourReset}")
+
+  if((${va_ver_major} GREATER_EQUAL 1) AND (${va_ver_minor} GREATER_EQUAL 5))
+    message("-- ${White}\tLibva Version Supported${ColourReset}")
+  else()
+    set(Libva_FOUND FALSE)
+    message("-- ${Yellow}\tLibva Version Not Supported${ColourReset}")
+  endif()
+endif()
+
+if(Libva_FOUND)
   if(NOT TARGET Libva::va)
     add_library(Libva::va UNKNOWN IMPORTED)
     set_target_properties(Libva::va PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIR}"

--- a/cmake/FindLibva.cmake
+++ b/cmake/FindLibva.cmake
@@ -21,9 +21,9 @@
 #
 ################################################################################
 
-find_library(LIBVA_LIBRARY NAMES va HINTS /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 NO_DEFAULT_PATH)
-find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 NO_DEFAULT_PATH)
-find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS /opt/amdgpu/include NO_DEFAULT_PATH)
+find_library(LIBVA_LIBRARY NAMES va HINTS /usr/lib/x86_64-linux-gnu /usr/lib64 /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64)
+find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS /usr/lib/x86_64-linux-gnu /usr/lib64 /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64)
+find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS /usr/include /opt/amdgpu/include)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY)

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -50,11 +50,17 @@ Prerequisites
   * Run: ``--usecase=rocm``
   * To install rocDecode with minimum requirements, follow the :doc:`quick-start instructions <./quick-start>`
 
-* AMD multimedia packages
+* Video Acceleration API Version `1.5.0`+ - `Libva` is an implementation for VA-API
 
   .. code:: shell
 
-   sudo apt install libva-dev mesa-amdgpu-va-drivers
+   sudo apt install libva-dev
+
+* AMD VA drivers
+
+  .. code:: shell
+
+   sudo apt install mesa-amdgpu-va-drivers
 
 * CMake 3.5 or later
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -25,7 +25,7 @@ Tested configurations
 
 * FFmpeg: 4.2.7/4.4.2-0
 
-* rocDecode Setup Script: V1.7.1
+* rocDecode Setup Script: V1.7.2
 
 Supported codecs
 ========================================

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -54,7 +54,7 @@ Prerequisites
 
   .. code:: shell
 
-   sudo apt install libva-amdgpu-dev libdrm-amdgpu1 mesa-amdgpu-va-drivers
+   sudo apt install libva-dev mesa-amdgpu-va-drivers
 
 * CMake 3.5 or later
 

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -138,6 +138,7 @@ coreDebianPackages = [
     'rocm-hip-runtime-dev',
     'libva2',
     'libva-dev',
+    'libdrm-amdgpu1',
     'mesa-amdgpu-va-drivers',
     'vainfo'
 ]
@@ -156,6 +157,7 @@ coreRPMPackages = [
     'rocm-hip-runtime-devel',
     'libva',
     'libva-devel',
+    'libdrm-amdgpu',
     'mesa-amdgpu-dri-drivers',
     'libva-utils'
 ]

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -95,9 +95,8 @@ if "centos" in platfromInfo or "redhat" in platfromInfo or os.path.exists('/usr/
     linuxSystemInstall = 'yum -y'
     linuxSystemInstall_check = '--nogpgcheck'
     if "centos-7" in platfromInfo or "redhat-7" in platfromInfo:
-        linuxCMake = 'cmake3'
-        sudoValidateOption= ''
-        ERROR_CHECK(os.system(linuxSystemInstall+' install cmake3'))
+        print("\nrocDecode Setup on "+platfromInfo+" is unsupported\n")
+        exit(-1)
     if not "centos" in platfromInfo or not "redhat" in platfromInfo:
         platfromInfo = platfromInfo+'-redhat'
 elif "Ubuntu" in platfromInfo or os.path.exists('/usr/bin/apt-get'):

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -28,7 +28,7 @@ else:
     import subprocess
 
 __copyright__ = "Copyright (c) 2023 - 2024, AMD ROCm rocDecode"
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 __email__ = "mivisionx.support@amd.com"
 __status__ = "Shipping"
 
@@ -90,11 +90,13 @@ linuxSystemInstall = ''
 linuxCMake = 'cmake'
 linuxSystemInstall_check = ''
 linuxFlag = ''
+sudoValidateOption= '-v'
 if "centos" in platfromInfo or "redhat" in platfromInfo or os.path.exists('/usr/bin/yum'):
     linuxSystemInstall = 'yum -y'
     linuxSystemInstall_check = '--nogpgcheck'
     if "centos-7" in platfromInfo or "redhat-7" in platfromInfo:
         linuxCMake = 'cmake3'
+        sudoValidateOption= ''
         ERROR_CHECK(os.system(linuxSystemInstall+' install cmake3'))
     if not "centos" in platfromInfo or not "redhat" in platfromInfo:
         platfromInfo = platfromInfo+'-redhat'
@@ -163,13 +165,13 @@ coreRPMPackages = [
 ]
 
 # common packages
-ERROR_CHECK(os.system('sudo -v'))
+ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 for i in range(len(commonPackages)):
     ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
             ' '+linuxSystemInstall_check+' install '+ commonPackages[i]))
 
 # rocDecode Core - LibVA Requirements
-ERROR_CHECK(os.system('sudo -v'))
+ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 if "Ubuntu" in platfromInfo:
     for i in range(len(coreDebianPackages)):
         ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
@@ -184,7 +186,7 @@ else:
                 ' '+linuxSystemInstall_check+' install '+ coreRPMPackages[i]))
 
 # rocDecode Dev Requirements
-ERROR_CHECK(os.system('sudo -v'))
+ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 if developerInstall == 'ON':
     if "Ubuntu" in platfromInfo:
         for i in range(len(ffmpegDebianPackages)):

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -129,13 +129,15 @@ commonPackages = [
     'wget',
     'unzip',
     'pkg-config',
-    'inxi'
+    'inxi',
+    'rocm-hip-runtime'
 ]
 
 # Debian packages
 coreDebianPackages = [
-    'libva-amdgpu-dev',
-    'libdrm-amdgpu1',
+    'rocm-hip-runtime-dev',
+    'libva2',
+    'libva-dev',
     'mesa-amdgpu-va-drivers',
     'vainfo'
 ]
@@ -151,8 +153,9 @@ ffmpegDebianPackages = [
 
 # RPM Packages
 coreRPMPackages = [
-    'libva-amdgpu-devel',
-    'libdrm-amdgpu',
+    'rocm-hip-runtime-devel',
+    'libva',
+    'libva-devel',
     'mesa-amdgpu-dri-drivers',
     'libva-utils'
 ]


### PR DESCRIPTION
* Find and link to public version of libva
* Support VA Version greater than 1.5.X
* Support link to AMDGPU VA headers if public unavailable
* Package link updates