### PR TITLE
rocDecode: Set the correct surface format for high bit depths in surface create call.

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -168,13 +168,19 @@ rocDecStatus VaapiVideoDecoder::CreateSurfaces() {
         return ROCDEC_INVALID_PARAMETER;
     }
     va_surface_ids_.resize(decoder_create_info_.num_decode_surfaces);
-    uint8_t surface_format;
+    uint32_t surface_format;
     switch (decoder_create_info_.chroma_format) {
         case rocDecVideoChromaFormat_Monochrome:
             surface_format = VA_RT_FORMAT_YUV400;
             break;
         case rocDecVideoChromaFormat_420:
-            surface_format = VA_RT_FORMAT_YUV420;
+            if (decoder_create_info_.bit_depth_minus_8 == 2) {
+                surface_format = VA_RT_FORMAT_YUV420_10;
+            } else if (decoder_create_info_.bit_depth_minus_8 == 4) {
+                surface_format = VA_RT_FORMAT_YUV420_12;
+            } else {
+                surface_format = VA_RT_FORMAT_YUV420;
+            }
             break;
         case rocDecVideoChromaFormat_422:
             surface_format = VA_RT_FORMAT_YUV422;


### PR DESCRIPTION
  - No functional changes as surface format does not affect the actual allocation of the VA surface in surface create call due to IHV specific implementation. The app still needs to set the format correctly.