### PR TITLE
videodecodeRGB sample re-org for rocPyDecode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ if(HIP_FOUND AND Libva_FOUND)
   install(FILES utils/colorspace_kernels.h DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT dev)
   install(FILES utils/resize_kernels.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT dev)
   install(FILES utils/resize_kernels.h DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT dev)
+  install(FILES utils/video_post_process.h DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT dev)
   install(FILES data/videos/AMD_driving_virtual_20-H265.mp4 data/videos/AMD_driving_virtual_20-H264.mp4 DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/video COMPONENT dev)
   # install license information - {ROCM_PATH}/share/doc/rocdecode
   set(CPACK_RESOURCE_FILE_LICENSE  "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")

--- a/samples/videoDecodeRGB/videodecrgb.cpp
+++ b/samples/videoDecodeRGB/videodecrgb.cpp
@@ -45,7 +45,6 @@ THE SOFTWARE.
 #include "resize_kernels.h"
 #include "video_post_process.h"
 
-//FILE *fpOut = nullptr;
 std::vector<std::string> st_output_format_name = {"native", "bgr", "bgr48", "rgb", "rgb48", "bgra", "bgra64", "rgba", "rgba64"};
 
 void ShowHelpAndExit(const char *option = NULL) {

--- a/samples/videoDecodeRGB/videodecrgb.cpp
+++ b/samples/videoDecodeRGB/videodecrgb.cpp
@@ -41,7 +41,6 @@ THE SOFTWARE.
 #include <atomic>
 #include "video_demuxer.h"
 #include "roc_video_dec.h"
-#include "colorspace_kernels.h"
 #include "video_post_process.h"
 
 std::vector<std::string> st_output_format_name = {"native", "bgr", "bgr48", "rgb", "rgb48", "bgra", "bgra64", "rgba", "rgba64"};

--- a/samples/videoDecodeRGB/videodecrgb.cpp
+++ b/samples/videoDecodeRGB/videodecrgb.cpp
@@ -42,7 +42,6 @@ THE SOFTWARE.
 #include "video_demuxer.h"
 #include "roc_video_dec.h"
 #include "colorspace_kernels.h"
-#include "resize_kernels.h"
 #include "video_post_process.h"
 
 std::vector<std::string> st_output_format_name = {"native", "bgr", "bgr48", "rgb", "rgb48", "bgra", "bgra64", "rgba", "rgba64"};

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -319,8 +319,9 @@ class RocVideoDecoder {
          * @param output_file_name  - Output file name
          * @param dev_mem           - pointer to surface memory
          * @param surf_info         - surface info
+         * @param rgb_image_size    - image size for rgb (optional). A non_zero value indicates the surf_mem holds an rgb interleaved image and the entire size will be dumped to file
          */
-        void SaveFrameToFile(std::string output_file_name, void *surf_mem, OutputSurfaceInfo *surf_info);
+        void SaveFrameToFile(std::string output_file_name, void *surf_mem, OutputSurfaceInfo *surf_info, size_t rgb_image_size = 0);
 
         /**
          * @brief Helper funtion to close a existing file and dump to new file in case of multiple files using same decoder

--- a/utils/video_post_process.h
+++ b/utils/video_post_process.h
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2023 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#pragma once
+
+#include "colorspace_kernels.h"
+#include "resize_kernels.h"
+#include "rocvideodecode/roc_video_dec.h"       //for OutputSurfaceInfo
+
+enum OutputFormatEnum {
+    native = 0, bgr, bgr48, rgb, rgb48, bgra, bgra64, rgba, rgba64
+};
+
+class VideoPostProcess {
+    public:
+        VideoPostProcess(){};
+        ~VideoPostProcess(){};
+        
+        void ColorConvertYUV2RGB(uint8_t *p_src, OutputSurfaceInfo *surf_info, uint8_t *rgb_dev_mem_ptr, OutputFormatEnum e_output_format, hipStream_t hip_stream) {
+            int  rgb_width = (surf_info->output_width + 1) & ~1;    // has to be a multiple of 2 for hip colorconvert kernels
+            // todo:: get color standard from the decoder
+            if (surf_info->surface_format == rocDecVideoSurfaceFormat_YUV444) {
+                if (e_output_format == bgr)
+                YUV444ToColor24<BGR24>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 3 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == bgra)
+                YUV444ToColor32<BGRA32>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 4 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgb)
+                YUV444ToColor24<RGB24>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 3 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgba)
+                YUV444ToColor32<RGBA32>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 4 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+            } else if (surf_info->surface_format == rocDecVideoSurfaceFormat_NV12) {
+                if (e_output_format == bgr)
+                Nv12ToColor24<BGR24>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 3 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == bgra)
+                Nv12ToColor32<BGRA32>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 4 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgb)
+                Nv12ToColor24<RGB24>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 3 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgba)
+                Nv12ToColor32<RGBA32>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 4 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+            }
+            if (surf_info->surface_format == rocDecVideoSurfaceFormat_YUV444_16Bit) {
+                if (e_output_format == bgr)
+                YUV444P16ToColor24<BGR24>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 3 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgb)
+                YUV444P16ToColor24<RGB24>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 3 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == bgr48)
+                YUV444P16ToColor48<BGR48>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 6 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgb48)
+                YUV444P16ToColor48<RGB48>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 6 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == bgra64)
+                YUV444P16ToColor64<BGRA64>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 8 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgba64)
+                YUV444P16ToColor64<RGBA64>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 8 * rgb_width, surf_info->output_width, 
+                                        surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+            } else if (surf_info->surface_format == rocDecVideoSurfaceFormat_P016) {
+                if (e_output_format == bgr)
+                P016ToColor24<BGR24>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 3 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgb)
+                P016ToColor24<RGB24>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 3 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == bgr48)
+                P016ToColor48<BGR48>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 6 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgb48)
+                P016ToColor48<RGB48>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 6 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == bgra64)
+                P016ToColor64<BGRA64>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 8 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+                else if (e_output_format == rgba64)
+                P016ToColor64<RGBA64>(p_src, surf_info->output_pitch, static_cast<uint8_t *>(rgb_dev_mem_ptr), 8 * rgb_width, surf_info->output_width, 
+                                    surf_info->output_height, surf_info->output_vstride, 0, hip_stream);
+            }
+        };
+};


### PR DESCRIPTION
moved color_convert function into a new file for using in rocPyDecode
removed dump_rgb and integrated into SaveFrameToFile