### PR TITLE
Samples - Add RPATH to address missing libs in path

### DIFF
--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -122,7 +122,30 @@ else()
   )
   mark_as_advanced(AVUTIL_LIBRARY)
 
-  if(AVCODEC_LIBRARY AND AVFORMAT_LIBRARY)
+    # SWSCALE  
+    find_path(SWSCALE_INCLUDE_DIR 
+    NAMES libswscale/swscale.h
+    PATHS ${_FFMPEG_SWSCALE_INCLUDE_DIRS}
+      /usr/include/x86_64-linux-gnu
+      /usr/local/include
+      /usr/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES ffmpeg libav sw
+  )
+  mark_as_advanced(SWSCALE_INCLUDE_DIR)
+  find_library(SWSCALE_LIBRARY
+    NAMES swscale
+    PATHS ${_FFMPEG_SWSCALE_LIBRARY_DIRS}
+      /usr/lib/x86_64-linux-gnu
+      /usr/local/lib
+      /usr/lib
+      /opt/local/lib
+      /sw/lib
+  )
+  mark_as_advanced(SWSCALE_LIBRARY)
+
+  if(AVCODEC_LIBRARY AND AVFORMAT_LIBRARY AND AVUTIL_LIBRARY AND SWSCALE_LIBRARY)
     set(FFMPEG_FOUND TRUE)
   endif()
   
@@ -143,6 +166,7 @@ else()
       ${AVCODEC_LIBRARY}
       ${AVFORMAT_LIBRARY}
       ${AVUTIL_LIBRARY}
+      ${SWSCALE_LIBRARY}
       CACHE INTERNAL ""
     )
   endif()

--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -145,7 +145,30 @@ else()
   )
   mark_as_advanced(SWSCALE_LIBRARY)
 
-  if(AVCODEC_LIBRARY AND AVFORMAT_LIBRARY AND AVUTIL_LIBRARY AND SWSCALE_LIBRARY)
+      # SWRESAMPLE 
+      find_path(SWRESAMPLE_INCLUDE_DIR 
+      NAMES libswresample/swresample.h
+      PATHS ${_FFMPEG_SWRESAMPLE_INCLUDE_DIRS}
+        /usr/include/x86_64-linux-gnu
+        /usr/local/include
+        /usr/include
+        /opt/local/include
+        /sw/include
+      PATH_SUFFIXES ffmpeg libav sw
+    )
+    mark_as_advanced(SWRESAMPLE_INCLUDE_DIR)
+    find_library(SWRESAMPLE_LIBRARY
+      NAMES swresample
+      PATHS ${_FFMPEG_SWRESAMPLE_LIBRARY_DIRS}
+        /usr/lib/x86_64-linux-gnu
+        /usr/local/lib
+        /usr/lib
+        /opt/local/lib
+        /sw/lib
+    )
+    mark_as_advanced(SWRESAMPLE_LIBRARY)
+
+  if(AVCODEC_LIBRARY AND AVFORMAT_LIBRARY AND AVUTIL_LIBRARY AND SWSCALE_LIBRARY AND SWRESAMPLE_LIBRARY)
     set(FFMPEG_FOUND TRUE)
   endif()
   
@@ -167,6 +190,7 @@ else()
       ${AVFORMAT_LIBRARY}
       ${AVUTIL_LIBRARY}
       ${SWSCALE_LIBRARY}
+      ${SWRESAMPLE_LIBRARY}
       CACHE INTERNAL ""
     )
   endif()

--- a/samples/videoDecode/CMakeLists.txt
+++ b/samples/videoDecode/CMakeLists.txt
@@ -89,6 +89,11 @@ if(HIP_FOUND AND FFMPEG_FOUND AND ROCDECODE_FOUND)
     else()
       target_compile_definitions(${PROJECT_NAME} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=1)
     endif()
+    ADD_CUSTOM_COMMAND(TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E env
+      "LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64/:/usr/local/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"
+    )
 else()
     message("-- ERROR!: ${PROJECT_NAME} excluded! please install all the dependencies and try again!")
     if (NOT HIP_FOUND)

--- a/samples/videoDecode/CMakeLists.txt
+++ b/samples/videoDecode/CMakeLists.txt
@@ -33,6 +33,8 @@ elseif(ROCM_PATH)
 else()
   set(ROCM_PATH /opt/rocm CACHE PATH "${White}${PROJECT_NAME}: Default ROCm installation path${ColourReset}")
 endif()
+# Add paths to linker search and installed rpath
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})

--- a/samples/videoDecodeBatch/CMakeLists.txt
+++ b/samples/videoDecodeBatch/CMakeLists.txt
@@ -33,6 +33,8 @@ elseif(ROCM_PATH)
 else()
   set(ROCM_PATH /opt/rocm CACHE PATH "${White}${PROJECT_NAME}: Default ROCm installation path${ColourReset}")
 endif()
+# Add paths to linker search and installed rpath
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})

--- a/samples/videoDecodeMem/CMakeLists.txt
+++ b/samples/videoDecodeMem/CMakeLists.txt
@@ -33,6 +33,8 @@ elseif(ROCM_PATH)
 else()
   set(ROCM_PATH /opt/rocm CACHE PATH "${White}${PROJECT_NAME}: Default ROCm installation path${ColourReset}")
 endif()
+# Add paths to linker search and installed rpath
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})

--- a/samples/videoDecodeMultiFiles/CMakeLists.txt
+++ b/samples/videoDecodeMultiFiles/CMakeLists.txt
@@ -33,6 +33,8 @@ elseif(ROCM_PATH)
 else()
   set(ROCM_PATH /opt/rocm CACHE PATH "${White}${PROJECT_NAME}: Default ROCm installation path${ColourReset}")
 endif()
+# Add paths to linker search and installed rpath
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})

--- a/samples/videoDecodePerf/CMakeLists.txt
+++ b/samples/videoDecodePerf/CMakeLists.txt
@@ -33,6 +33,8 @@ elseif(ROCM_PATH)
 else()
   set(ROCM_PATH /opt/rocm CACHE PATH "${White}${PROJECT_NAME}: Default ROCm installation path${ColourReset}")
 endif()
+# Add paths to linker search and installed rpath
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})

--- a/samples/videoDecodeRGB/CMakeLists.txt
+++ b/samples/videoDecodeRGB/CMakeLists.txt
@@ -33,6 +33,8 @@ elseif(ROCM_PATH)
 else()
   set(ROCM_PATH /opt/rocm CACHE PATH "${White}${PROJECT_NAME}: Default ROCm installation path${ColourReset}")
 endif()
+# Add paths to linker search and installed rpath
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})


### PR DESCRIPTION
*  Add RPATH to address missing libs in path
* Applications are not installed or distributed with the package