### PR TITLE
rocDecode: Added decode buffer pool implementation for AVC and HEVC.

### DIFF
--- a/samples/videoDecode/README.md
+++ b/samples/videoDecode/README.md
@@ -32,6 +32,7 @@ make -j
               -d <GPU device ID - 0:device 0 / 1:device 1/ ... [optional - default:0]>
               -f <Number of decoded frames - specify the number of pictures to be decoded [optional]>
               -z <force_zero_latency - Decoded frames will be flushed out for display immediately [optional]>
+              -disp_delay <display delay - specify the number of frames to be delayed for display [optional]>
               -sei <extract SEI messages [optional]>
               -md5 <generate MD5 message digest on the decoded YUV image sequence [optional]>
               -md5_check MD5_File_Path <generate MD5 message digest on the decoded YUV image sequence and compare to the reference MD5 string in a file [optional]>

--- a/samples/videoDecode/videodecode.cpp
+++ b/samples/videoDecode/videodecode.cpp
@@ -47,6 +47,7 @@ void ShowHelpAndExit(const char *option = NULL) {
     << "-d GPU device ID (0 for the first device, 1 for the second, etc.); optional; default: 0" << std::endl
     << "-f Number of decoded frames - specify the number of pictures to be decoded; optional" << std::endl
     << "-z force_zero_latency (force_zero_latency, Decoded frames will be flushed out for display immediately); optional;" << std::endl
+    << "-disp_delay -specify the number of frames to be delayed for display; optional;" << std::endl
     << "-sei extract SEI messages; optional;" << std::endl
     << "-md5 generate MD5 message digest on the decoded YUV image sequence; optional;" << std::endl
     << "-md5_check MD5 File Path - generate MD5 message digest on the decoded YUV image sequence and compare to the reference MD5 string in a file; optional;" << std::endl
@@ -66,6 +67,7 @@ int main(int argc, char **argv) {
     std::fstream ref_md5_file;
     int dump_output_frames = 0;
     int device_id = 0;
+    int disp_delay = 0;
     bool b_force_zero_latency = false;     // false by default: enabling this option might affect decoding performance
     bool b_extract_sei_messages = false;
     bool b_generate_md5 = false;
@@ -109,6 +111,13 @@ int main(int argc, char **argv) {
                 ShowHelpAndExit("-d");
             }
             device_id = atoi(argv[i]);
+            continue;
+        }
+        if (!strcmp(argv[i], "-disp_delay")) {
+            if (++i == argc) {
+                ShowHelpAndExit("-disp_delay");
+            }
+            disp_delay = atoi(argv[i]);
             continue;
         }
         if (!strcmp(argv[i], "-f")) {
@@ -197,7 +206,7 @@ int main(int argc, char **argv) {
         VideoDemuxer demuxer(input_file_path.c_str());
         VideoSeekContext video_seek_ctx;
         rocDecVideoCodec rocdec_codec_id = AVCodec2RocDecVideoCodec(demuxer.GetCodecID());
-        RocVideoDecoder viddec(device_id, mem_type, rocdec_codec_id, b_force_zero_latency, p_crop_rect, b_extract_sei_messages);
+        RocVideoDecoder viddec(device_id, mem_type, rocdec_codec_id, b_force_zero_latency, p_crop_rect, b_extract_sei_messages, disp_delay);
 
         std::string device_name, gcn_arch_name;
         int pci_bus_id, pci_domain_id, pci_device_id;

--- a/src/parser/avc_defines.h
+++ b/src/parser/avc_defines.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 #define AVC_MAX_REF_FRAME_NUM                           16
 #define AVC_MAX_REF_PICTURE_NUM                         32
-#define AVC_MAX_DPB_FRAMES                              18
+#define AVC_MAX_DPB_FRAMES                              16 // Jefftest2
 #define AVC_MAX_DPB_FIELDS                              AVC_MAX_DPB_FRAMES * 2
 
 #define AVC_MACRO_BLOCK_SIZE                            16

--- a/src/parser/avc_defines.h
+++ b/src/parser/avc_defines.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 #define AVC_MAX_REF_FRAME_NUM                           16
 #define AVC_MAX_REF_PICTURE_NUM                         32
-#define AVC_MAX_DPB_FRAMES                              16 // Jefftest2
+#define AVC_MAX_DPB_FRAMES                              16
 #define AVC_MAX_DPB_FIELDS                              AVC_MAX_DPB_FRAMES * 2
 
 #define AVC_MACRO_BLOCK_SIZE                            16

--- a/src/parser/avc_parser.cpp
+++ b/src/parser/avc_parser.cpp
@@ -740,6 +740,8 @@ ParserResult AvcVideoParser::SendPicForDecode() {
     }
 }
 
+// Jefftest6
+#if 0
 ParserResult AvcVideoParser::OutputDecodedPictures(bool no_delay) {
     RocdecParserDispInfo disp_info = {0};
     disp_info.progressive_frame = sps_list_[active_sps_id_].frame_mbs_only_flag;
@@ -788,6 +790,7 @@ ParserResult AvcVideoParser::OutputDecodedPictures(bool no_delay) {
 #endif
     return PARSER_OK;
 }
+#endif
 
 AvcNalUnitHeader AvcVideoParser::ParseNalUnitHeader(uint8_t header_byte) {
     size_t bit_offset = 0;

--- a/src/parser/avc_parser.cpp
+++ b/src/parser/avc_parser.cpp
@@ -3083,9 +3083,12 @@ ParserResult AvcVideoParser::BumpPicFromDpb() {
             } else */{
                 // Jefftest dpb_buffer_.output_pic_list[dpb_buffer_.num_output_pics] = min_poc_pic_idx_ref;
                 // Jefftest1 output_pic_list_[num_output_pics_] = min_poc_pic_idx_ref;
+                // Jefftest4
+            if (pfn_display_picture_cb_) {
                 output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx_ref].dec_buf_idx;
                 // Jefftest dpb_buffer_.num_output_pics++;
                 num_output_pics_++;
+            }
             }
         }
         min_poc_ref = 0x7FFFFFFF;
@@ -3113,9 +3116,12 @@ ParserResult AvcVideoParser::BumpPicFromDpb() {
         } else */{
             // Jefftest dpb_buffer_.output_pic_list[dpb_buffer_.num_output_pics] = min_poc_pic_idx_no_ref;
             // Jefftest1 output_pic_list_[num_output_pics_] = min_poc_pic_idx_no_ref;
+        // Jefftest4
+        if (pfn_display_picture_cb_) {
             output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx_no_ref].dec_buf_idx;
             // Jefftest dpb_buffer_.num_output_pics++;
             num_output_pics_++;
+        }
         }
     }
     // Remove it from DPB.

--- a/src/parser/avc_parser.h
+++ b/src/parser/avc_parser.h
@@ -157,7 +157,7 @@ protected:
      * \param [in] no_delay Indicator to override the display delay parameter wth no delay 
      * \return <tt>ParserResult</tt>
      */
-    ParserResult OutputDecodedPictures(bool no_delay);
+    // Jefftest6 ParserResult OutputDecodedPictures(bool no_delay);
 
     /*! \brief Callback function to send parsed SEI playload to decoder.
      */

--- a/src/parser/avc_parser.h
+++ b/src/parser/avc_parser.h
@@ -153,10 +153,11 @@ protected:
      */
     ParserResult SendPicForDecode();
 
-    /*! \brief Function to output decoded pictures from DPB for post-processing.
-     * \return Return code in ParserResult form
+    /*! \brief Callback function to output decoded pictures from DPB for post-processing.
+     * \param [in] no_delay Indicator to override the display delay parameter wth no delay 
+     * \return <tt>ParserResult</tt>
      */
-    ParserResult OutputDecodedPictures();
+    ParserResult OutputDecodedPictures(bool no_delay);
 
     /*! \brief Callback function to send parsed SEI playload to decoder.
      */

--- a/src/parser/avc_parser.h
+++ b/src/parser/avc_parser.h
@@ -60,6 +60,8 @@ public:
 
     typedef struct {
         int      pic_idx;  // picture index or id
+        // Jefftest
+        int      dec_buf_idx;  // frame index in decode buffer pool
         PictureStructure pic_structure;
         int32_t  pic_order_cnt;
         int32_t  top_field_order_cnt;
@@ -134,6 +136,7 @@ protected:
     uint32_t field_pic_count_;
     int second_field_;
     int first_field_pic_idx_;
+    int first_field_dec_buf_idx_; // Jefftest1
 
     // DPB
     AvcPicture curr_pic_;
@@ -262,6 +265,11 @@ protected:
      * \return <tt>ParserResult</tt>
      */
     ParserResult CheckDpbAndOutput();
+
+    /*! \brief Function to find a free buffer in the decode buffer pool
+     *  \return <tt>ParserResult</tt>
+     */
+    ParserResult FindFreeInDecBufPool();
 
     /*! \brief Function to find a free buffer in DPB for the current picture
      * \return <tt>ParserResult</tt>

--- a/src/parser/avc_parser.h
+++ b/src/parser/avc_parser.h
@@ -60,7 +60,6 @@ public:
 
     typedef struct {
         int      pic_idx;  // picture index or id
-        // Jefftest
         int      dec_buf_idx;  // frame index in decode buffer pool
         PictureStructure pic_structure;
         int32_t  pic_order_cnt;
@@ -136,7 +135,7 @@ protected:
     uint32_t field_pic_count_;
     int second_field_;
     int first_field_pic_idx_;
-    int first_field_dec_buf_idx_; // Jefftest1
+    int first_field_dec_buf_idx_;
 
     // DPB
     AvcPicture curr_pic_;
@@ -152,12 +151,6 @@ protected:
      * \return <tt>ParserResult</tt>
      */
     ParserResult SendPicForDecode();
-
-    /*! \brief Callback function to output decoded pictures from DPB for post-processing.
-     * \param [in] no_delay Indicator to override the display delay parameter wth no delay 
-     * \return <tt>ParserResult</tt>
-     */
-    // Jefftest6 ParserResult OutputDecodedPictures(bool no_delay);
 
     /*! \brief Callback function to send parsed SEI playload to decoder.
      */

--- a/src/parser/avc_parser.h
+++ b/src/parser/avc_parser.h
@@ -71,7 +71,7 @@ public:
         int32_t  long_term_pic_num; // LongTermPicNum
         uint32_t long_term_frame_idx; // LongTermFrameIdx: long term reference frame/field identifier
         uint32_t is_reference;
-        uint32_t use_status;  // 0 = empty; 1 = top used; 2 = bottom used; 3 = both fields or frame used
+        uint32_t use_status;
         uint32_t pic_output_flag;  // OutputFlag
     } AvcPicture;
 

--- a/src/parser/avc_parser.h
+++ b/src/parser/avc_parser.h
@@ -71,7 +71,7 @@ public:
         int32_t  long_term_pic_num; // LongTermPicNum
         uint32_t long_term_frame_idx; // LongTermFrameIdx: long term reference frame/field identifier
         uint32_t is_reference;
-        uint32_t use_status;
+        uint32_t use_status;    // refer to FrameBufUseStatus
         uint32_t pic_output_flag;  // OutputFlag
     } AvcPicture;
 

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -2336,7 +2336,8 @@ ParserResult HevcVideoParser::FindFreeInDecBufPool() {
 
     curr_pic_info_.dec_buf_idx = dec_buf_index;
     decode_buffer_pool_[dec_buf_index].dec_use_status = 3;
-    if (curr_pic_info_.pic_output_flag) {
+    // Jefftest4 if (curr_pic_info_.pic_output_flag) {
+    if (pfn_display_picture_cb_ && curr_pic_info_.pic_output_flag) {
         decode_buffer_pool_[dec_buf_index].disp_use_status = 3;
     }
     decode_buffer_pool_[dec_buf_index].pic_order_cnt = curr_pic_info_.pic_order_cnt;
@@ -2412,7 +2413,8 @@ ParserResult HevcVideoParser::FindFreeBufAndMark() {
     // Jefftest
     // Mark as used in decode buffer pool
     decode_buffer_pool_[curr_pic_info_.dec_buf_idx].dec_use_status = 3;
-    if (curr_pic_info_.pic_output_flag) {
+    // Jefftest4 if (curr_pic_info_.pic_output_flag) {
+    if (pfn_display_picture_cb_ && curr_pic_info_.pic_output_flag) {
         decode_buffer_pool_[curr_pic_info_.dec_buf_idx].disp_use_status = 3;
     }
     decode_buffer_pool_[curr_pic_info_.dec_buf_idx].pic_order_cnt = curr_pic_info_.pic_order_cnt;
@@ -2534,17 +2536,20 @@ int HevcVideoParser::BumpPicFromDpb() {
     }
 
     // Insert into output/display picture list
-    // Jefftest if (dpb_buffer_.num_output_pics >= HEVC_MAX_DPB_FRAMES) {
-    if (num_output_pics_ >= HEVC_MAX_DPB_FRAMES) {
-        ERR("Error! DPB output buffer list overflow!");
-        return PARSER_OUT_OF_RANGE;
-    } else {
-        // Jefftest dpb_buffer_.output_pic_list[dpb_buffer_.num_output_pics] = min_poc_pic_idx;
-        // Jefftest output_pic_list_[num_output_pics_] = min_poc_pic_idx;
-        output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].dec_buf_idx;
-        //decode_buffer_pool_[output_pic_list_[num_output_pics_]].pic_order_cnt = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].pic_order_cnt;
-        // Jefftest dpb_buffer_.num_output_pics++;
-        num_output_pics_++;
+    // Jefftest4
+    if (pfn_display_picture_cb_) {
+        // Jefftest if (dpb_buffer_.num_output_pics >= HEVC_MAX_DPB_FRAMES) {
+        if (num_output_pics_ >= HEVC_MAX_DPB_FRAMES) {
+            ERR("Error! DPB output buffer list overflow!");
+            return PARSER_OUT_OF_RANGE;
+        } else {
+            // Jefftest dpb_buffer_.output_pic_list[dpb_buffer_.num_output_pics] = min_poc_pic_idx;
+            // Jefftest output_pic_list_[num_output_pics_] = min_poc_pic_idx;
+            output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].dec_buf_idx;
+            //decode_buffer_pool_[output_pic_list_[num_output_pics_]].pic_order_cnt = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].pic_order_cnt;
+            // Jefftest dpb_buffer_.num_output_pics++;
+            num_output_pics_++;
+        }
     }
 
     return PARSER_OK;

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -2335,12 +2335,12 @@ ParserResult HevcVideoParser::FindFreeInDecBufPool() {
     }
 
     curr_pic_info_.dec_buf_idx = dec_buf_index;
-    decode_buffer_pool_[dec_buf_index].dec_use_status = 3;
+    /* Jefftest5 decode_buffer_pool_[dec_buf_index].dec_use_status = 3;
     // Jefftest4 if (curr_pic_info_.pic_output_flag) {
     if (pfn_display_picture_cb_ && curr_pic_info_.pic_output_flag) {
         decode_buffer_pool_[dec_buf_index].disp_use_status = 3;
     }
-    decode_buffer_pool_[dec_buf_index].pic_order_cnt = curr_pic_info_.pic_order_cnt;
+    decode_buffer_pool_[dec_buf_index].pic_order_cnt = curr_pic_info_.pic_order_cnt;*/
     return PARSER_OK;
 }
 

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -572,6 +572,8 @@ int HevcVideoParser::SendPicForDecode() {
     }
 }
 
+// Jefftest6
+#if 0
 ParserResult HevcVideoParser::OutputDecodedPictures(bool no_delay) {
     RocdecParserDispInfo disp_info = {0};
     disp_info.progressive_frame = m_sps_[m_active_sps_id_].profile_tier_level.general_progressive_source_flag;
@@ -621,6 +623,7 @@ ParserResult HevcVideoParser::OutputDecodedPictures(bool no_delay) {
 #endif
     return PARSER_OK;
 }
+#endif
 
 ParserResult HevcVideoParser::ParsePictureData(const uint8_t* p_stream, uint32_t pic_data_size) {
     ParserResult ret = PARSER_OK;

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -92,9 +92,6 @@ rocDecStatus HevcVideoParser::UnInitialize() {
 rocDecStatus HevcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     if (p_data->payload && p_data->payload_size) {
         //printf("Frame %d: =====================================================\n", pic_count_); // Jefftest
-        if (pic_count_ == 96) {
-            pic_count_ = 96;
-        }
         // Clear DPB output/display buffer number
         // Jefftest dpb_buffer_.num_output_pics = 0;
         // Jefftest3 num_output_pics_ = 0;
@@ -2546,7 +2543,6 @@ int HevcVideoParser::BumpPicFromDpb() {
             // Jefftest dpb_buffer_.output_pic_list[dpb_buffer_.num_output_pics] = min_poc_pic_idx;
             // Jefftest output_pic_list_[num_output_pics_] = min_poc_pic_idx;
             output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].dec_buf_idx;
-            //decode_buffer_pool_[output_pic_list_[num_output_pics_]].pic_order_cnt = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].pic_order_cnt;
             // Jefftest dpb_buffer_.num_output_pics++;
             num_output_pics_++;
         }
@@ -2967,6 +2963,14 @@ void HevcVideoParser::PrintDpb() {
     for(i = 0; i < dec_buf_pool_size_; i++) {
         DecodeFrameBuffer *p_dec_buf = &decode_buffer_pool_[i];
         MSG("Decode buffer " << i << ": surface_idx = " << p_dec_buf->surface_idx << ", dec_use_status = " << p_dec_buf->dec_use_status << ", disp_use_status = " << p_dec_buf->disp_use_status << ", pic_order_cnt = " << p_dec_buf->pic_order_cnt);
+    }
+    MSG("num_output_pics_ = " << num_output_pics_);
+    if (num_output_pics_) {
+        MSG("output_pic_list:");
+        for (i = 0; i < num_output_pics_; i++) {
+            MSG_NO_NEWLINE(output_pic_list_[i] << ", ");
+        }
+        MSG("");
     }
 }
 

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -91,6 +91,10 @@ rocDecStatus HevcVideoParser::UnInitialize() {
 
 rocDecStatus HevcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     if (p_data->payload && p_data->payload_size) {
+        printf("Frame %d: =====================================================\n", pic_count_); // Jefftest
+        if (pic_count_ == 20) {
+            pic_count_ = 20;
+        }
         // Clear DPB output/display buffer number
         // Jefftest dpb_buffer_.num_output_pics = 0;
         num_output_pics_ = 0;
@@ -252,7 +256,8 @@ void HevcVideoParser::SendSeiMsgPayload() {
     sei_message_info_params_.sei_message_count = sei_message_count_;
     sei_message_info_params_.sei_message = sei_message_list_.data();
     sei_message_info_params_.sei_data = (void*)sei_payload_buf_;
-    sei_message_info_params_.picIdx = curr_pic_info_.pic_idx;
+    // Jefftest sei_message_info_params_.picIdx = curr_pic_info_.pic_idx;
+    sei_message_info_params_.picIdx = curr_pic_info_.dec_buf_idx;
 
     // callback function with RocdecSeiMessageInfo params filled out
     if (pfn_get_sei_message_cb_) pfn_get_sei_message_cb_(parser_params_.user_data, &sei_message_info_params_);
@@ -266,7 +271,8 @@ int HevcVideoParser::SendPicForDecode() {
 
     dec_pic_params_.pic_width = sps_ptr->pic_width_in_luma_samples;
     dec_pic_params_.pic_height = sps_ptr->pic_height_in_luma_samples;
-    dec_pic_params_.curr_pic_idx = curr_pic_info_.pic_idx;
+    // Jefftest dec_pic_params_.curr_pic_idx = curr_pic_info_.pic_idx;
+    dec_pic_params_.curr_pic_idx = curr_pic_info_.dec_buf_idx;
     dec_pic_params_.field_pic_flag = sps_ptr->profile_tier_level.general_interlaced_source_flag;
     dec_pic_params_.bottom_field_flag = 0; // For now. Need to parse VUI/SEI pic_timing()
     dec_pic_params_.second_field = 0; // For now. Need to parse VUI/SEI pic_timing()
@@ -285,14 +291,16 @@ int HevcVideoParser::SendPicForDecode() {
     RocdecHevcPicParams *pic_param_ptr = &dec_pic_params_.pic_params.hevc;
 
     // Current picture
-    pic_param_ptr->curr_pic.pic_idx = curr_pic_info_.pic_idx;
+    // Jefftest pic_param_ptr->curr_pic.pic_idx = curr_pic_info_.pic_idx;
+    pic_param_ptr->curr_pic.pic_idx = curr_pic_info_.dec_buf_idx;
     pic_param_ptr->curr_pic.poc = curr_pic_info_.pic_order_cnt;
 
     // Reference pictures
     ref_idx = 0;
     for (i = 0; i < num_poc_st_curr_before_; i++) {
         buf_idx = ref_pic_set_st_curr_before_[i];  // buffer index in DPB
-        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        // Jefftest pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].dec_buf_idx;
         pic_param_ptr->ref_frames[ref_idx].poc = dpb_buffer_.frame_buffer_list[buf_idx].pic_order_cnt;
         pic_param_ptr->ref_frames[ref_idx].flags = 0; // assume frame picture for now
         pic_param_ptr->ref_frames[ref_idx].flags |= RocdecHevcPicture_RPS_ST_CURR_BEFORE;
@@ -301,7 +309,8 @@ int HevcVideoParser::SendPicForDecode() {
 
     for (i = 0; i < num_poc_st_curr_after_; i++) {
         buf_idx = ref_pic_set_st_curr_after_[i]; // buffer index in DPB
-        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        // Jefftest pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].dec_buf_idx;
         pic_param_ptr->ref_frames[ref_idx].poc = dpb_buffer_.frame_buffer_list[buf_idx].pic_order_cnt;
         pic_param_ptr->ref_frames[ref_idx].flags = 0; // assume frame picture for now
         pic_param_ptr->ref_frames[ref_idx].flags |= RocdecHevcPicture_RPS_ST_CURR_AFTER;
@@ -310,7 +319,8 @@ int HevcVideoParser::SendPicForDecode() {
 
     for (i = 0; i < num_poc_lt_curr_; i++) {
         buf_idx = ref_pic_set_lt_curr_[i]; // buffer index in DPB
-        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        // Jefftest pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].dec_buf_idx;
         pic_param_ptr->ref_frames[ref_idx].poc = dpb_buffer_.frame_buffer_list[buf_idx].pic_order_cnt;
         pic_param_ptr->ref_frames[ref_idx].flags = 0; // assume frame picture for now
         pic_param_ptr->ref_frames[ref_idx].flags |= RocdecHevcPicture_LONG_TERM_REFERENCE | RocdecHevcPicture_RPS_LT_CURR;
@@ -319,7 +329,8 @@ int HevcVideoParser::SendPicForDecode() {
 
     for (i = 0; i < num_poc_st_foll_; i++) {
         buf_idx = ref_pic_set_st_foll_[i]; // buffer index in DPB
-        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        // Jefftest pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].dec_buf_idx;
         pic_param_ptr->ref_frames[ref_idx].poc = dpb_buffer_.frame_buffer_list[buf_idx].pic_order_cnt;
         pic_param_ptr->ref_frames[ref_idx].flags = 0; // assume frame picture for now
         ref_idx++;
@@ -327,7 +338,8 @@ int HevcVideoParser::SendPicForDecode() {
 
     for (i = 0; i < num_poc_lt_foll_; i++) {
         buf_idx = ref_pic_set_lt_foll_[i]; // buffer index in DPB
-        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        // Jefftest pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].pic_idx;
+        pic_param_ptr->ref_frames[ref_idx].pic_idx = dpb_buffer_.frame_buffer_list[buf_idx].dec_buf_idx;
         pic_param_ptr->ref_frames[ref_idx].poc = dpb_buffer_.frame_buffer_list[buf_idx].pic_order_cnt;
         pic_param_ptr->ref_frames[ref_idx].flags = 0; // assume frame picture for now
         ref_idx++;
@@ -439,8 +451,10 @@ int HevcVideoParser::SendPicForDecode() {
         if (p_slice_header->slice_type != HEVC_SLICE_TYPE_I) {
             for (i = 0; i <= p_slice_header->num_ref_idx_l0_active_minus1; i++) {
                 int idx = p_slice_info->ref_pic_list_0_[i]; // pic_idx of the ref pic
+                int dec_buf_idx = dpb_buffer_.frame_buffer_list[idx].dec_buf_idx; // Jefftest
                 for (j = 0; j < 15; j++) {
-                    if (pic_param_ptr->ref_frames[j].pic_idx == idx) {
+                    // Jefftest if (pic_param_ptr->ref_frames[j].pic_idx == idx) {
+                    if (pic_param_ptr->ref_frames[j].pic_idx == dec_buf_idx) {
                         break;
                     }
                 }
@@ -455,8 +469,10 @@ int HevcVideoParser::SendPicForDecode() {
             if (p_slice_header->slice_type == HEVC_SLICE_TYPE_B) {
                 for (i = 0; i <= p_slice_header->num_ref_idx_l1_active_minus1; i++) {
                     int idx = p_slice_info->ref_pic_list_1_[i]; // pic_idx of the ref pic
+                    int dec_buf_idx = dpb_buffer_.frame_buffer_list[idx].dec_buf_idx; // Jefftest
                     for (j = 0; j < 15; j++) {
-                        if (pic_param_ptr->ref_frames[j].pic_idx == idx) {
+                        // Jefftest if (pic_param_ptr->ref_frames[j].pic_idx == idx) {
+                        if (pic_param_ptr->ref_frames[j].pic_idx == dec_buf_idx) {
                             break;
                         }
                     }
@@ -547,6 +563,10 @@ int HevcVideoParser::SendPicForDecode() {
         }
     }
 
+#if DBGINFO
+    PrintVappiBufInfo();
+#endif // DBGINFO
+
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
         ERR("Decode error occurred.");
         return PARSER_FAIL;
@@ -560,11 +580,16 @@ int HevcVideoParser::OutputDecodedPictures() {
     disp_info.progressive_frame = m_sps_[m_active_sps_id_].profile_tier_level.general_progressive_source_flag;
     disp_info.top_field_first = 1;
 
+    printf("OutputDecodedPictures(): num_output_pics_ = %d\n", num_output_pics_);
     // Jefftest for (int i = 0; i < dpb_buffer_.num_output_pics; i++) {
     for (int i = 0; i < num_output_pics_; i++) {
         // Jefftest disp_info.picture_index = dpb_buffer_.frame_buffer_list[dpb_buffer_.output_pic_list[i]].pic_idx;
-        disp_info.picture_index = dpb_buffer_.frame_buffer_list[output_pic_list_[i]].pic_idx;
+        // Jefftest disp_info.picture_index = dpb_buffer_.frame_buffer_list[output_pic_list_[i]].pic_idx;
+        disp_info.picture_index = decode_buffer_pool_[output_pic_list_[i]].surface_idx;
         pfn_display_picture_cb_(parser_params_.user_data, &disp_info);
+        // Jefftest
+        decode_buffer_pool_[output_pic_list_[i]].disp_use_status = 0;
+        printf("POC = %d, surface_idx = %d\n", decode_buffer_pool_[output_pic_list_[i]].pic_order_cnt, decode_buffer_pool_[output_pic_list_[i]].surface_idx); // Jefftest
     }
 
     // Jefftest dpb_buffer_.num_output_pics = 0;
@@ -685,6 +710,12 @@ ParserResult HevcVideoParser::ParsePictureData(const uint8_t* p_stream, uint32_t
                         // Get POC. 8.3.1.
                         CalculateCurrPoc();
 
+                        // Jefftest1
+                        // Locate a free buffer for the current picutre in decode buffer pool before output picture marking (C.5.2.2)
+                        if (FindFreeInDecBufPool() != PARSER_OK) {
+                            return PARSER_FAIL;
+                        }
+
                         // Decode RPS. 8.3.2.
                         DecodeRps();
                     }
@@ -704,6 +735,10 @@ ParserResult HevcVideoParser::ParsePictureData(const uint8_t* p_stream, uint32_t
                         if (FindFreeBufAndMark() != PARSER_OK) {
                             return PARSER_FAIL;
                         }
+
+#if DBGINFO
+                        PrintDpb();
+#endif // DBGINFO
                     }
                     num_slices_++;
                     break;
@@ -2156,7 +2191,7 @@ void HevcVideoParser::InitDpb() {
     dpb_buffer_.dpb_fullness = 0;
     dpb_buffer_.num_pics_needed_for_output = 0;
     // Jefftest dpb_buffer_.num_output_pics = 0;
-    num_output_pics_ = 0;
+    // Jefftest num_output_pics_ = 0;
 }
 
 void HevcVideoParser::EmptyDpb() {
@@ -2164,8 +2199,11 @@ void HevcVideoParser::EmptyDpb() {
         dpb_buffer_.frame_buffer_list[i].is_reference = kUnusedForReference;
         dpb_buffer_.frame_buffer_list[i].pic_output_flag = 0;
         dpb_buffer_.frame_buffer_list[i].use_status = 0;
+        // Jefftest
+        decode_buffer_pool_[dpb_buffer_.frame_buffer_list[i].dec_buf_idx].dec_use_status = 0;
+        decode_buffer_pool_[dpb_buffer_.frame_buffer_list[i].dec_buf_idx].disp_use_status = 0;
         // Jefftest dpb_buffer_.output_pic_list[i] = 0xFF;
-        output_pic_list_[i] = 0xFF;
+        // Jefftest output_pic_list_[i] = 0xFF;
     }
     dpb_buffer_.dpb_fullness = 0;
     dpb_buffer_.num_pics_needed_for_output = 0;
@@ -2213,6 +2251,8 @@ int HevcVideoParser::MarkOutputPictures() {
         for (i = 0; i < HEVC_MAX_DPB_FRAMES; i++) {
             if (dpb_buffer_.frame_buffer_list[i].is_reference == kUnusedForReference && dpb_buffer_.frame_buffer_list[i].pic_output_flag == 0 && dpb_buffer_.frame_buffer_list[i].use_status) {
                 dpb_buffer_.frame_buffer_list[i].use_status = 0;
+                // Jefftest
+                decode_buffer_pool_[dpb_buffer_.frame_buffer_list[i].dec_buf_idx].dec_use_status = 0;
                 if (dpb_buffer_.dpb_fullness > 0) {
                     dpb_buffer_.dpb_fullness--;
                 } else {
@@ -2245,11 +2285,48 @@ int HevcVideoParser::MarkOutputPictures() {
     return PARSER_OK;
 }
 
+ParserResult HevcVideoParser::FindFreeInDecBufPool() {
+    int dec_buf_index;
+
+    // Find a free buffer in decode buffer pool
+    for (dec_buf_index = 0; dec_buf_index < dec_buf_pool_size_; dec_buf_index++) {
+        if (decode_buffer_pool_[dec_buf_index].dec_use_status == 0 && decode_buffer_pool_[dec_buf_index].disp_use_status == 0) {
+            break;
+        }
+    }
+    if (dec_buf_index == dec_buf_pool_size_) {
+        ERR("Could not find a free buffer in decode buffer pool.");
+        return PARSER_NOT_FOUND;
+    }
+
+    curr_pic_info_.dec_buf_idx = dec_buf_index;
+    decode_buffer_pool_[dec_buf_index].dec_use_status = 3;
+    if (curr_pic_info_.pic_output_flag) {
+        decode_buffer_pool_[dec_buf_index].disp_use_status = 3;
+    }
+    decode_buffer_pool_[dec_buf_index].pic_order_cnt = curr_pic_info_.pic_order_cnt;
+    return PARSER_OK;
+}
+
+#define NewBufManage 1
 #if NewBufManage
 ParserResult HevcVideoParser::FindFreeBufAndMark() {
     int i, j;
+    // Jefftest1
+    /*int dec_buf_index;
 
-    // Look for an empty buffer with longest decode history (lowest decode count)
+    // Find a free buffer in decode buffer pool
+    for (dec_buf_index = 0; dec_buf_index < dec_buf_pool_size_; dec_buf_index++) {
+        if (decode_buffer_pool_[dec_buf_index].dec_use_status == 0 && decode_buffer_pool_[dec_buf_index].disp_use_status == 0) {
+            break;
+        }
+    }
+    if (dec_buf_index == dec_buf_pool_size_) {
+        ERR("Could not find a free buffer in decode buffer pool.");
+        return PARSER_NOT_FOUND;
+    }*/
+
+    // Look for an empty buffer in DPB with longest decode history (lowest decode count)
     uint32_t min_decode_order_count = 0xFFFFFFFF;
     int index = dpb_buffer_.dpb_size;
     for (i = 0; i < dpb_buffer_.dpb_size; i++) {
@@ -2259,12 +2336,12 @@ ParserResult HevcVideoParser::FindFreeBufAndMark() {
                 // decode the current picture into any buffers in the output list
                 bool is_in_output_list = false;
                 // Jefftest for (j = 0; j < dpb_buffer_.num_output_pics; j++) {
-                for (j = 0; j < num_output_pics_; j++) {
+                /*for (j = 0; j < num_output_pics_; j++) {
                     // Jefftest if (dpb_buffer_.output_pic_list[j] == i) {
                     if (output_pic_list_[j] == i) {
                         is_in_output_list = true;
                     }
-                }
+                }*/
                 if (!is_in_output_list) {
                     min_decode_order_count = dpb_buffer_.frame_buffer_list[i].decode_order_count;
                     index = i;
@@ -2278,8 +2355,11 @@ ParserResult HevcVideoParser::FindFreeBufAndMark() {
     }
 
     curr_pic_info_.pic_idx = index;
+    // Jefftest1 
+    //curr_pic_info_.dec_buf_idx = dec_buf_index;
     curr_pic_info_.is_reference = kUsedForShortTerm;
     // dpb_buffer_.frame_buffer_list[i].pic_idx is already set in InitDpb().
+    dpb_buffer_.frame_buffer_list[index].dec_buf_idx = curr_pic_info_.dec_buf_idx;
     dpb_buffer_.frame_buffer_list[index].pic_order_cnt = curr_pic_info_.pic_order_cnt;
     dpb_buffer_.frame_buffer_list[index].prev_poc_lsb = curr_pic_info_.prev_poc_lsb;
     dpb_buffer_.frame_buffer_list[index].prev_poc_msb = curr_pic_info_.prev_poc_msb;
@@ -2293,6 +2373,14 @@ ParserResult HevcVideoParser::FindFreeBufAndMark() {
         dpb_buffer_.num_pics_needed_for_output++;
     }
     dpb_buffer_.dpb_fullness++;
+
+    // Jefftest
+    // Mark as used in decode buffer pool
+    decode_buffer_pool_[curr_pic_info_.dec_buf_idx].dec_use_status = 3;
+    if (curr_pic_info_.pic_output_flag) {
+        decode_buffer_pool_[curr_pic_info_.dec_buf_idx].disp_use_status = 3;
+    }
+    decode_buffer_pool_[curr_pic_info_.dec_buf_idx].pic_order_cnt = curr_pic_info_.pic_order_cnt;
 
     HevcSeqParamSet *sps_ptr = &m_sps_[m_active_sps_id_];
     uint32_t highest_tid = sps_ptr->sps_max_sub_layers_minus1; // HighestTid
@@ -2310,7 +2398,7 @@ ParserResult HevcVideoParser::FindFreeBufAndMark() {
     return PARSER_OK;
 }
 #else
-int HevcVideoParser::FindFreeBufAndMark() {
+ParserResult HevcVideoParser::FindFreeBufAndMark() {
     int i, j;
 
     // Look for an empty buffer with longest decode history (lowest decode count)
@@ -2322,8 +2410,10 @@ int HevcVideoParser::FindFreeBufAndMark() {
                 // Check if this picture has been bumped to the output/display list. If yes, skip it because we do not want to
                 // decode the current picture into any buffers in the output list
                 bool is_in_output_list = false;
-                for (j = 0; j < dpb_buffer_.num_output_pics; j++) {
-                    if (dpb_buffer_.output_pic_list[j] == i) {
+                // Jefftest for (j = 0; j < dpb_buffer_.num_output_pics; j++) {
+                for (j = 0; j < num_output_pics_; j++) {
+                    // Jefftest if (dpb_buffer_.output_pic_list[j] == i) {
+                    if (output_pic_list_[j] == i) {
                         is_in_output_list = true;
                     }
                 }
@@ -2400,6 +2490,8 @@ int HevcVideoParser::BumpPicFromDpb() {
     // If it is not used for reference, empty it.
     if (dpb_buffer_.frame_buffer_list[min_poc_pic_idx].is_reference == kUnusedForReference) {
         dpb_buffer_.frame_buffer_list[min_poc_pic_idx].use_status = 0;
+        // Jefftest
+        decode_buffer_pool_[dpb_buffer_.frame_buffer_list[min_poc_pic_idx].dec_buf_idx].dec_use_status = 0;
         if (dpb_buffer_.dpb_fullness > 0 ) {
             dpb_buffer_.dpb_fullness--;
         }
@@ -2412,7 +2504,9 @@ int HevcVideoParser::BumpPicFromDpb() {
         return PARSER_OUT_OF_RANGE;
     } else {
         // Jefftest dpb_buffer_.output_pic_list[dpb_buffer_.num_output_pics] = min_poc_pic_idx;
-        output_pic_list_[num_output_pics_] = min_poc_pic_idx;
+        // Jefftest output_pic_list_[num_output_pics_] = min_poc_pic_idx;
+        output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].dec_buf_idx;
+        //decode_buffer_pool_[output_pic_list_[num_output_pics_]].pic_order_cnt = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].pic_order_cnt;
         // Jefftest dpb_buffer_.num_output_pics++;
         num_output_pics_++;
     }
@@ -2722,7 +2816,7 @@ void HevcVideoParser::PrintSliceSegHeader(HevcSliceSegHeader *slice_header_ptr) 
     MSG("slice_qp_delta                              = " <<  slice_header_ptr->slice_qp_delta);
     MSG("slice_cb_qp_offset                          = " <<  slice_header_ptr->slice_cb_qp_offset);
     MSG("slice_cr_qp_offset                          = " <<  slice_header_ptr->slice_cr_qp_offset);
-    MSG("cu_chroma_qp_offset_enabled_flag            = " <<  slice_header_ptr->cu_chroma_qp_offset_enabled_flag);
+    MSG("cu_chroma_qp_offset_enabled_flag            = " <<  static_cast<uint32_t>(slice_header_ptr->cu_chroma_qp_offset_enabled_flag));
     MSG("deblocking_filter_override_flag             = " <<  slice_header_ptr->deblocking_filter_override_flag);
     MSG("slice_deblocking_filter_disabled_flag       = " <<  slice_header_ptr->slice_deblocking_filter_disabled_flag);
     MSG("slice_beta_offset_div2                      = " <<  slice_header_ptr->slice_beta_offset_div2);
@@ -2736,18 +2830,18 @@ void HevcVideoParser::PrintSliceSegHeader(HevcSliceSegHeader *slice_header_ptr) 
 
 void HevcVideoParser::PrintStRps(HevcShortTermRps *rps_ptr) {
     MSG("==== Short-term reference picture set =====")
-    MSG("inter_ref_pic_set_prediction_flag           = " <<  rps_ptr->inter_ref_pic_set_prediction_flag);
+    MSG("inter_ref_pic_set_prediction_flag           = " <<  static_cast<uint32_t>(rps_ptr->inter_ref_pic_set_prediction_flag));
     MSG("delta_idx_minus1                            = " <<  rps_ptr->delta_idx_minus1);
-    MSG("delta_rps_sign                              = " <<  rps_ptr->delta_rps_sign);
+    MSG("delta_rps_sign                              = " <<  static_cast<uint32_t>(rps_ptr->delta_rps_sign));
     MSG("abs_delta_rps_minus1                        = " <<  rps_ptr->abs_delta_rps_minus1);
     MSG_NO_NEWLINE("rps->used_by_curr_pic_flag[]:");
     for(int j = 0; j < 16; j++) {
-        MSG_NO_NEWLINE(" " << rps_ptr->used_by_curr_pic_flag[j]);
+        MSG_NO_NEWLINE(" " << static_cast<uint32_t>(rps_ptr->used_by_curr_pic_flag[j]));
     }
     MSG("");
     MSG_NO_NEWLINE("use_delta_flag[]:");
     for(int j = 0; j < 16; j++) {
-        MSG_NO_NEWLINE(" " << rps_ptr->use_delta_flag[j]);
+        MSG_NO_NEWLINE(" " << static_cast<uint32_t>(rps_ptr->use_delta_flag[j]));
     }
     MSG("");
     MSG("num_negative_pics                           = " <<  rps_ptr->num_negative_pics);
@@ -2761,7 +2855,7 @@ void HevcVideoParser::PrintStRps(HevcShortTermRps *rps_ptr) {
     MSG("");
     MSG_NO_NEWLINE("used_by_curr_pic_s0_flag[]:");
     for(int j = 0; j < 16; j++) {
-        MSG_NO_NEWLINE(" " << rps_ptr->used_by_curr_pic_s0_flag[j]);
+        MSG_NO_NEWLINE(" " << static_cast<uint32_t>(rps_ptr->used_by_curr_pic_s0_flag[j]));
     }
     MSG("");
     MSG_NO_NEWLINE("delta_poc_s1_minus1[]:");
@@ -2771,7 +2865,7 @@ void HevcVideoParser::PrintStRps(HevcShortTermRps *rps_ptr) {
     MSG("");
     MSG_NO_NEWLINE("used_by_curr_pic_s1_flag[]:");
     for(int j = 0; j < 16; j++) {
-        MSG_NO_NEWLINE(" " << rps_ptr->used_by_curr_pic_s1_flag[j]);
+        MSG_NO_NEWLINE(" " << static_cast<uint32_t>(rps_ptr->used_by_curr_pic_s1_flag[j]));
     }
     MSG("");
 
@@ -2787,12 +2881,12 @@ void HevcVideoParser::PrintStRps(HevcShortTermRps *rps_ptr) {
     MSG("");
     MSG_NO_NEWLINE("used_by_curr_pic_s0[16]:");
     for(int j = 0; j < 16; j++) {
-        MSG_NO_NEWLINE(" " << rps_ptr->used_by_curr_pic_s0[j]);
+        MSG_NO_NEWLINE(" " << static_cast<uint32_t>(rps_ptr->used_by_curr_pic_s0[j]));
     }
     MSG("");
     MSG_NO_NEWLINE("used_by_curr_pic_s1[16]:");
     for(int j = 0; j < 16; j++) {
-        MSG_NO_NEWLINE(" " << rps_ptr->used_by_curr_pic_s1[j]);
+        MSG_NO_NEWLINE(" " << static_cast<uint32_t>(rps_ptr->used_by_curr_pic_s1[j]));
     }
     MSG("");
 }
@@ -2810,5 +2904,64 @@ void HevcVideoParser::PrintLtRefInfo(HevcLongTermRps *lt_info_ptr) {
         MSG_NO_NEWLINE(" " << lt_info_ptr->used_by_curr_pic[j]);
     }
     MSG("");
+}
+
+void HevcVideoParser::PrintDpb() {
+    uint32_t i;
+
+    MSG("=======================");
+    MSG("DPB buffer content: ");
+    MSG("=======================");
+    MSG("dpb_size = " << dpb_buffer_.dpb_size);
+    MSG("num_pics_needed_for_output = " << dpb_buffer_.num_pics_needed_for_output);
+    MSG("dpb_fullness = " << dpb_buffer_.dpb_fullness);
+    MSG("Frame buffer store:");
+    for (i = 0; i < HEVC_MAX_DPB_FRAMES; i++) {
+        HevcPicInfo *p_buf = &dpb_buffer_.frame_buffer_list[i];
+        MSG("Frame buffer " << i << ": pic_idx = " << p_buf->pic_idx << ", dec_buf_idx = " << p_buf->dec_buf_idx << ", pic_order_cnt = " << p_buf->pic_order_cnt << ", slice_pic_order_cnt_lsb = " << p_buf->slice_pic_order_cnt_lsb << ", decode_order_count = " << p_buf->decode_order_count << ", is_reference = " << p_buf->is_reference << ", use_status = " << p_buf->use_status << ", pic_output_flag = " << p_buf->pic_output_flag);
+    }
+    MSG("");
+
+    MSG("Decode buffer pool:");
+    for(i = 0; i < dec_buf_pool_size_; i++) {
+        DecodeFrameBuffer *p_dec_buf = &decode_buffer_pool_[i];
+        MSG("Decode buffer " << i << ": surface_idx = " << p_dec_buf->surface_idx << ", dec_use_status = " << p_dec_buf->dec_use_status << ", disp_use_status = " << p_dec_buf->disp_use_status << ", pic_order_cnt = " << p_dec_buf->pic_order_cnt);
+    }
+}
+
+void HevcVideoParser::PrintVappiBufInfo() {
+    RocdecHevcPicParams *p_pic_param = &dec_pic_params_.pic_params.hevc;
+    MSG("=======================");
+    MSG("VAAPI Buffer Info: ");
+    MSG("=======================");
+    MSG("Current buffer:");
+    MSG_NO_NEWLINE("pic_idx = " << p_pic_param->curr_pic.pic_idx << ", poc = " << p_pic_param->curr_pic.poc);
+    MSG(", flags = 0x" << std::hex << p_pic_param->curr_pic.flags);
+    MSG(std::dec);
+
+    MSG("Reference pictures:");
+    for (int i = 0; i < 15; i++) {
+        RocdecHevcPicture *p_ref_pic = &p_pic_param->ref_frames[i];
+        MSG_NO_NEWLINE("Ref pic " << i << ": " << "pic_idx = " << p_ref_pic->pic_idx << ", poc = " << p_ref_pic->poc);
+        MSG(", flags = 0x" << std::hex << p_ref_pic->flags);
+        MSG_NO_NEWLINE(std::dec);
+    }
+
+    MSG("Slice ref lists:")
+    for (int slice_index = 0; slice_index < num_slices_; slice_index++) {
+        RocdecHevcSliceParams *p_slice_param = &slice_param_list_[slice_index];
+        HevcSliceInfo *p_slice_info = &slice_info_list_[slice_index];
+        MSG("Slice " << slice_index << " ref list 0:");
+        for (int i = 0; i <= p_slice_info->slice_header.num_ref_idx_l0_active_minus1; i++) {
+            MSG("Index " << i << ": " << static_cast<uint32_t>(p_slice_param->ref_pic_list[0][i]));
+        }
+        if (p_slice_info->slice_header.slice_type == HEVC_SLICE_TYPE_B) {
+            MSG("Slice " << slice_index << " ref list 1: ");
+            for (int i = 0; i <= p_slice_info->slice_header.num_ref_idx_l1_active_minus1; i++) {
+                MSG("Index " << i << ": " << static_cast<uint32_t>(p_slice_param->ref_pic_list[1][i]));
+            }
+        }
+        MSG("");
+    }
 }
 #endif // DBGINFO

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -362,7 +362,7 @@ private:
      * \param [in] no_delay Indicator to override the display delay parameter wth no delay 
      * \return <tt>ParserResult</tt>
      */
-    ParserResult OutputDecodedPictures(bool no_delay);
+    // Jefftest6 ParserResult OutputDecodedPictures(bool no_delay);
 
     bool IsIdrPic(HevcNalUnitHeader *nal_header_ptr);
     bool IsCraPic(HevcNalUnitHeader *nal_header_ptr);

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -359,9 +359,10 @@ private:
     int SendPicForDecode();
 
     /*! \brief Callback function to output decoded pictures from DPB for post-processing.
-     * \return Return code in ParserResult form
+     * \param [in] no_delay Indicator to override the display delay parameter wth no delay 
+     * \return <tt>ParserResult</tt>
      */
-    int OutputDecodedPictures(int flush);
+    ParserResult OutputDecodedPictures(bool no_delay);
 
     bool IsIdrPic(HevcNalUnitHeader *nal_header_ptr);
     bool IsCraPic(HevcNalUnitHeader *nal_header_ptr);

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -98,7 +98,6 @@ protected:
      */
     typedef struct {
         int     pic_idx;  // picture index or id
-        // Jefftest
         int     dec_buf_idx;  // frame index in decode buffer pool
         // POC info
         int32_t pic_order_cnt;  // PicOrderCnt
@@ -120,9 +119,6 @@ protected:
         uint32_t num_pics_needed_for_output;  // number of pictures in DPB that need to be output
         uint32_t dpb_fullness;  // number of pictures in DPB
         HevcPicInfo frame_buffer_list[HEVC_MAX_DPB_FRAMES];
-
-        // Jefftest uint32_t num_output_pics;  // number of pictures that are output after the decode call
-        // Jefftest uint32_t output_pic_list[HEVC_MAX_DPB_FRAMES]; // sorted output picuture index to frame_buffer_list[]
     } DecodedPictureBuffer;
 
     // Data members of HEVC class
@@ -357,12 +353,6 @@ private:
      * \return Return code in ParserResult form
      */
     int SendPicForDecode();
-
-    /*! \brief Callback function to output decoded pictures from DPB for post-processing.
-     * \param [in] no_delay Indicator to override the display delay parameter wth no delay 
-     * \return <tt>ParserResult</tt>
-     */
-    // Jefftest6 ParserResult OutputDecodedPictures(bool no_delay);
 
     bool IsIdrPic(HevcNalUnitHeader *nal_header_ptr);
     bool IsCraPic(HevcNalUnitHeader *nal_header_ptr);

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -358,7 +358,7 @@ private:
     /*! \brief Callback function to output decoded pictures from DPB for post-processing.
      * \return Return code in ParserResult form
      */
-    int OutputDecodedPictures();
+    int OutputDecodedPictures(int flush);
 
     bool IsIdrPic(HevcNalUnitHeader *nal_header_ptr);
     bool IsCraPic(HevcNalUnitHeader *nal_header_ptr);

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -119,8 +119,8 @@ protected:
         uint32_t dpb_fullness;  // number of pictures in DPB
         HevcPicInfo frame_buffer_list[HEVC_MAX_DPB_FRAMES];
 
-        uint32_t num_output_pics;  // number of pictures that are output after the decode call
-        uint32_t output_pic_list[HEVC_MAX_DPB_FRAMES]; // sorted output picuture index to frame_buffer_list[]
+        // Jefftest uint32_t num_output_pics;  // number of pictures that are output after the decode call
+        // Jefftest uint32_t output_pic_list[HEVC_MAX_DPB_FRAMES]; // sorted output picuture index to frame_buffer_list[]
     } DecodedPictureBuffer;
 
     // Data members of HEVC class
@@ -310,9 +310,9 @@ protected:
 
     /*! \brief Function to find a free buffer in DPB for the current picture and mark it. Additional picture
      *         bumping is done if needed. C.5.2.3.
-     * \return Code in ParserResult form.
+     * \return <tt>ParserResult</tt>
      */
-    int FindFreeBufAndMark();
+    ParserResult FindFreeBufAndMark();
 
     /*! \brief Function to bump one picture out of DPB. C.5.2.4.
      * \return Code in ParserResult form.

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -310,6 +310,9 @@ protected:
      */
     int MarkOutputPictures();
 
+    /*! \brief Function to find a free buffer in the decode buffer pool
+     *  \return <tt>ParserResult</tt>
+     */
     ParserResult FindFreeInDecBufPool();
 
     /*! \brief Function to find a free buffer in DPB for the current picture and mark it. Additional picture

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -98,6 +98,8 @@ protected:
      */
     typedef struct {
         int     pic_idx;  // picture index or id
+        // Jefftest
+        int     dec_buf_idx;  // frame index in decode buffer pool
         // POC info
         int32_t pic_order_cnt;  // PicOrderCnt
         int32_t prev_poc_lsb;  // prevPicOrderCntLsb
@@ -307,6 +309,8 @@ protected:
      * \return Code in ParserResult form.
      */
     int MarkOutputPictures();
+
+    ParserResult FindFreeInDecBufPool();
 
     /*! \brief Function to find a free buffer in DPB for the current picture and mark it. Additional picture
      *         bumping is done if needed. C.5.2.3.

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -337,6 +337,8 @@ protected:
     void PrintSliceSegHeader(HevcSliceSegHeader *slice_header_ptr);
     void PrintStRps(HevcShortTermRps *rps_ptr);
     void PrintLtRefInfo(HevcLongTermRps *lt_info_ptr);
+    void PrintDpb();
+    void PrintVappiBufInfo();
 #endif // DBGINFO
 
 private:

--- a/src/parser/hevc_parser.h
+++ b/src/parser/hevc_parser.h
@@ -108,7 +108,7 @@ protected:
 
         uint32_t pic_output_flag;  // PicOutputFlag
         uint32_t is_reference;
-        uint32_t use_status;  // 0 = empty; 1 = top used; 2 = bottom used; 3 = both fields or frame used
+        uint32_t use_status;    // refer to FrameBufUseStatus
     } HevcPicInfo;
 
     /*! \brief Decoded picture buffer
@@ -315,7 +315,7 @@ protected:
      *         bumping is done if needed. C.5.2.3.
      * \return <tt>ParserResult</tt>
      */
-    ParserResult FindFreeBufAndMark();
+    ParserResult FindFreeInDpbAndMark();
 
     /*! \brief Function to bump one picture out of DPB. C.5.2.4.
      * \return Code in ParserResult form.

--- a/src/parser/roc_video_parser.cpp
+++ b/src/parser/roc_video_parser.cpp
@@ -70,7 +70,9 @@ rocDecStatus RocVideoParser::Initialize(RocdecParserParams *pParams) {
 void RocVideoParser::InitDecBufPool() {
     for (int i = 0; i < dec_buf_pool_size_; i++) {
         decode_buffer_pool_[i].surface_idx = i;
-        decode_buffer_pool_[i].use_status = 0;
+        decode_buffer_pool_[i].dec_use_status = 0;
+        decode_buffer_pool_[i].disp_use_status = 0;
+        decode_buffer_pool_[i].pic_order_cnt = 0;
         output_pic_list_[i] = 0xFF;
     }
     num_output_pics_ = 0;

--- a/src/parser/roc_video_parser.cpp
+++ b/src/parser/roc_video_parser.cpp
@@ -67,6 +67,15 @@ rocDecStatus RocVideoParser::Initialize(RocdecParserParams *pParams) {
     return ROCDEC_SUCCESS;
 }
 
+void RocVideoParser::InitDecBufPool() {
+    for (int i = 0; i < dec_buf_pool_size_; i++) {
+        decode_buffer_pool_[i].surface_idx = i;
+        decode_buffer_pool_[i].use_status = 0;
+        output_pic_list_[i] = 0xFF;
+    }
+    num_output_pics_ = 0;
+}
+
 ParserResult RocVideoParser::GetNalUnit() {
     bool start_code_found = false;
 

--- a/src/parser/roc_video_parser.cpp
+++ b/src/parser/roc_video_parser.cpp
@@ -74,9 +74,7 @@ rocDecStatus RocVideoParser::Initialize(RocdecParserParams *pParams) {
 
 void RocVideoParser::InitDecBufPool() {
     for (int i = 0; i < dec_buf_pool_size_; i++) {
-        decode_buffer_pool_[i].surface_idx = i;
-        decode_buffer_pool_[i].dec_use_status = 0;
-        decode_buffer_pool_[i].disp_use_status = 0;
+        decode_buffer_pool_[i].use_status = kNotUsed;
         decode_buffer_pool_[i].pic_order_cnt = 0;
         output_pic_list_[i] = 0xFF;
     }
@@ -102,9 +100,9 @@ ParserResult RocVideoParser::OutputDecodedPictures(bool no_delay) {
     if (num_output_pics_ > disp_delay) {
         int num_disp = num_output_pics_ - disp_delay;
         for (int i = 0; i < num_disp; i++) {
-            disp_info.picture_index = decode_buffer_pool_[output_pic_list_[i]].surface_idx;
+            disp_info.picture_index = output_pic_list_[i];
             pfn_display_picture_cb_(parser_params_.user_data, &disp_info);
-            decode_buffer_pool_[output_pic_list_[i]].disp_use_status = 0;
+            decode_buffer_pool_[output_pic_list_[i]].use_status &= ~kFrameUsedForDisplay;
         }
 
         num_output_pics_ = disp_delay;

--- a/src/parser/roc_video_parser.h
+++ b/src/parser/roc_video_parser.h
@@ -99,8 +99,10 @@ public:
 
 protected:
     typedef struct {
-        uint32_t surface_idx;       // VA surface index
-        uint32_t use_status;        // 0 = empty; 1 = top used; 2 = bottom used; 3 = both fields or frame used
+        uint32_t surface_idx;           // VA surface index
+        uint32_t dec_use_status;        // 0 = not used for decode (bumped out of DPB); 1 = top used; 2 = bottom used; 3 = both fields or frame used
+        uint32_t disp_use_status;       // 0 = displayed or not need for display; 1 = top used; 2 = bottom used; 3 = both fields or frame used
+        uint32_t pic_order_cnt; // Jefftest
     } DecodeFrameBuffer;
 
     RocdecParserParams parser_params_ = {};

--- a/src/parser/roc_video_parser.h
+++ b/src/parser/roc_video_parser.h
@@ -98,13 +98,6 @@ public:
     virtual rocDecStatus UnInitialize() = 0;     // pure virtual: implemented by derived class
 
 protected:
-    typedef struct {
-        uint32_t surface_idx;           // VA surface index
-        uint32_t dec_use_status;        // 0 = not used for decode (bumped out of DPB); 1 = top used; 2 = bottom used; 3 = both fields or frame used
-        uint32_t disp_use_status;       // 0 = displayed or not need for display; 1 = top used; 2 = bottom used; 3 = both fields or frame used
-        uint32_t pic_order_cnt; // Jefftest
-    } DecodeFrameBuffer;
-
     RocdecParserParams parser_params_ = {};
 
     /*! \brief callback function pointers for the parser
@@ -120,6 +113,12 @@ protected:
     bool new_sps_activated_;
 
     // Decoded buffer pool
+    typedef struct {
+        uint32_t surface_idx;           // VA surface index
+        uint32_t dec_use_status;        // 0 = not used for decode (bumped out of DPB); 1 = top used; 2 = bottom used; 3 = both fields or frame used
+        uint32_t disp_use_status;       // 0 = displayed or not need for display; 1 = top used; 2 = bottom used; 3 = both fields or frame used
+        uint32_t pic_order_cnt; // Jefftest
+    } DecodeFrameBuffer;
     uint32_t dec_buf_pool_size_;        /* Number of decoded frame surfaces in the pool which are recycled. The size should be greater
                                            than or equal to DPB size (normally greater to guarantee smooth operations). The value is
                                            set to max_num_decode_surfaces from the decoder but parser checks and increases if needed. */

--- a/src/parser/roc_video_parser.h
+++ b/src/parser/roc_video_parser.h
@@ -158,6 +158,12 @@ protected:
     uint32_t            sei_payload_buf_size_;
     uint32_t            sei_payload_size_;  // total SEI payload size of the current frame
 
+    /*! \brief Callback function to output decoded pictures from DPB for post-processing.
+     * \param [in] no_delay Indicator to override the display delay parameter wth no delay
+     * \return <tt>ParserResult</tt>
+     */
+    ParserResult OutputDecodedPictures(bool no_delay);
+
     /*! \brief Function to get the NAL Unit data
      * \return Returns OK if successful, else error code
      */

--- a/src/parser/roc_video_parser.h
+++ b/src/parser/roc_video_parser.h
@@ -27,9 +27,6 @@ THE SOFTWARE.
 #include "rocparser.h"
 #include "../commons.h"
 
-// Jefftest
-#define NewBufManage 1
-
 typedef enum ParserResult {
     PARSER_OK                                   = 0,
     PARSER_FAIL                                    ,
@@ -117,7 +114,7 @@ protected:
         uint32_t surface_idx;           // VA surface index
         uint32_t dec_use_status;        // 0 = not used for decode (bumped out of DPB); 1 = top used; 2 = bottom used; 3 = both fields or frame used
         uint32_t disp_use_status;       // 0 = displayed or not need for display; 1 = top used; 2 = bottom used; 3 = both fields or frame used
-        uint32_t pic_order_cnt; // Jefftest
+        uint32_t pic_order_cnt;
     } DecodeFrameBuffer;
     uint32_t dec_buf_pool_size_;        /* Number of decoded frame surfaces in the pool which are recycled. The size should be greater
                                            than or equal to DPB size (normally greater to guarantee smooth operations). The value is

--- a/src/parser/roc_video_parser.h
+++ b/src/parser/roc_video_parser.h
@@ -78,6 +78,7 @@ typedef struct {
 #define INIT_SLICE_LIST_NUM 16 // initial slice information/parameter struct list size
 #define INIT_SEI_MESSAGE_COUNT 16  // initial SEI message count
 #define INIT_SEI_PAYLOAD_BUF_SIZE 1024 * 1024  // initial SEI payload buffer size, 1 MB
+#define DECODE_BUF_POOL_EXTENSION 2
 
 /**
  * @brief Base class for video parsing
@@ -154,6 +155,11 @@ protected:
     uint8_t             *sei_payload_buf_;  // buffer to store SEI playload. Allocated at run time.
     uint32_t            sei_payload_buf_size_;
     uint32_t            sei_payload_size_;  // total SEI payload size of the current frame
+
+    /*! \brief Function to check the initially set (by decoder) decode buffer pool size and adjust if needed
+     *  \param dpb_size The DPB buffer size of the current sequence
+     */
+    void CheckAndAdjustDecBufPoolSize(int dpb_size);
 
     /*! \brief Callback function to output decoded pictures from DPB for post-processing.
      * \param [in] no_delay Indicator to override the display delay parameter wth no delay

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -39,9 +39,9 @@ RocVideoDecoder::RocVideoDecoder(int device_id, OutputSurfaceMemoryType out_mem_
     // create rocdec videoparser
     RocdecParserParams parser_params = {};
     parser_params.codec_type = codec_id_;
-    parser_params.max_num_decode_surfaces = 1;
+    parser_params.max_num_decode_surfaces = MAX_DPB_FRAMES + DISPLAY_DELAY;
     parser_params.clock_rate = clk_rate;
-    parser_params.max_display_delay = 0;
+    parser_params.max_display_delay = DISPLAY_DELAY;
     parser_params.user_data = this;
     parser_params.pfn_sequence_callback = HandleVideoSequenceProc;
     parser_params.pfn_decode_picture = HandlePictureDecodeProc;

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -39,6 +39,7 @@ RocVideoDecoder::RocVideoDecoder(int device_id, OutputSurfaceMemoryType out_mem_
     // create rocdec videoparser
     RocdecParserParams parser_params = {};
     parser_params.codec_type = codec_id_;
+    // Note this is tunable
     parser_params.max_num_decode_surfaces = MAX_DPB_FRAMES + DISPLAY_DELAY;
     parser_params.clock_rate = clk_rate;
     parser_params.max_display_delay = DISPLAY_DELAY;

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -23,9 +23,9 @@ THE SOFTWARE.
 #include "roc_video_dec.h"
 
 RocVideoDecoder::RocVideoDecoder(int device_id, OutputSurfaceMemoryType out_mem_type, rocDecVideoCodec codec, bool force_zero_latency,
-              const Rect *p_crop_rect, bool extract_user_sei_Message, int max_width, int max_height, uint32_t clk_rate) :
+              const Rect *p_crop_rect, bool extract_user_sei_Message, uint32_t disp_delay, int max_width, int max_height, uint32_t clk_rate) :
               device_id_{device_id}, out_mem_type_(out_mem_type), codec_id_(codec), b_force_zero_latency_(force_zero_latency), 
-              b_extract_sei_message_(extract_user_sei_Message), max_width_ (max_width), max_height_(max_height) {
+              b_extract_sei_message_(extract_user_sei_Message), disp_delay_(disp_delay), max_width_ (max_width), max_height_(max_height) {
 
     if (!InitHIP(device_id_)) {
         THROW("Failed to initilize the HIP");
@@ -39,10 +39,9 @@ RocVideoDecoder::RocVideoDecoder(int device_id, OutputSurfaceMemoryType out_mem_
     // create rocdec videoparser
     RocdecParserParams parser_params = {};
     parser_params.codec_type = codec_id_;
-    // Note this is tunable
-    parser_params.max_num_decode_surfaces = MAX_DPB_FRAMES + DISPLAY_DELAY;
+    parser_params.max_num_decode_surfaces = 1; // let the parser to determine the decode buffer pool size
     parser_params.clock_rate = clk_rate;
-    parser_params.max_display_delay = DISPLAY_DELAY;
+    parser_params.max_display_delay = disp_delay_;
     parser_params.user_data = this;
     parser_params.pfn_sequence_callback = HandleVideoSequenceProc;
     parser_params.pfn_decode_picture = HandlePictureDecodeProc;

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -50,7 +50,10 @@ extern "C" {
  * \brief AMD The rocDecode video decoder for AMD’s GPUs.
  */
 
-#define MAX_FRAME_NUM     16
+#define MAX_FRAME_NUM       16
+#define MAX_DPB_FRAMES      16
+#define DISPLAY_DELAY       2
+
 typedef int (ROCDECAPI *PFNRECONFIGUEFLUSHCALLBACK)(void *, uint32_t, void *);
 
 typedef enum SeiAvcHevcPayloadType_enum {

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -51,8 +51,6 @@ extern "C" {
  */
 
 #define MAX_FRAME_NUM       16
-#define MAX_DPB_FRAMES      16
-#define DISPLAY_DELAY       2
 
 typedef int (ROCDECAPI *PFNRECONFIGUEFLUSHCALLBACK)(void *, uint32_t, void *);
 
@@ -180,7 +178,7 @@ class RocVideoDecoder {
        * @param force_zero_latency 
        */
         RocVideoDecoder(int device_id,  OutputSurfaceMemoryType out_mem_type, rocDecVideoCodec codec, bool force_zero_latency = false,
-                          const Rect *p_crop_rect = nullptr, bool extract_user_SEI_Message = false, int max_width = 0, int max_height = 0,
+                          const Rect *p_crop_rect = nullptr, bool extract_user_SEI_Message = false, uint32_t disp_delay = 0, int max_width = 0, int max_height = 0,
                           uint32_t clk_rate = 1000);
         ~RocVideoDecoder();
         
@@ -429,6 +427,7 @@ class RocVideoDecoder {
         OutputSurfaceMemoryType out_mem_type_ = OUT_SURFACE_MEM_DEV_INTERNAL;
         bool b_extract_sei_message_ = false;
         bool b_force_zero_latency_ = false;
+        uint32_t disp_delay_;
         ReconfigParams *p_reconfig_params_ = nullptr;
         int32_t num_frames_flushed_during_reconfig_ = 0;
         hipDeviceProp_t hip_dev_prop_;


### PR DESCRIPTION
- Now DPB buffer management is decoupled from decode buffer pool management.
- User can now specify the decode buffer pool size and set display delay parameter.
- Conformance tests on MI250/MI300/Navi31 remain passing.
- Tests on MI250/MI300A/Navi31 showed no performance regressions.
- Multiple session and very long session stability tests on MI250/MI300A/Navi31 showed no issues.