### PR TITLE
Add support for handling exceptions while using the std::filesystem::recursive_directory_iterator

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -436,13 +436,8 @@ void VaapiVideoDecoder::GetCurrentComputePartition(std::vector<ComputePartition>
     std::string search_path = "/sys/devices/";
     std::string partition_file = "current_compute_partition";
     std::error_code ec;
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-    if (std::filesystem::exists(search_path)) {
-        for (auto it = std::filesystem::recursive_directory_iterator(search_path, std::filesystem::directory_options::skip_permission_denied); it != std::filesystem::recursive_directory_iterator(); ) {
-#else
-    if (std::experimental::filesystem::exists(search_path)) {
-        for (auto it = std::experimental::filesystem::recursive_directory_iterator(search_path, std::experimental::filesystem::directory_options::skip_permission_denied); it != std::experimental::filesystem::recursive_directory_iterator(); ) {
-#endif
+    if (fs::exists(search_path)) {
+        for (auto it = fs::recursive_directory_iterator(search_path, fs::directory_options::skip_permission_denied); it != fs::recursive_directory_iterator(); ) {
             try {
                 if (it->path().filename() == partition_file) {
                     std::ifstream file(it->path());
@@ -464,11 +459,7 @@ void VaapiVideoDecoder::GetCurrentComputePartition(std::vector<ComputePartition>
                     }
                 }
                 ++it;
-#if __cplusplus >= 201703L && __has_include(<filesystem>)
-            } catch (std::filesystem::filesystem_error& e) {
-#else
-            } catch (std::experimental::filesystem::filesystem_error& e) {
-#endif
+            } catch (fs::filesystem_error& e) {
                 it.increment(ec);
             }
         }

--- a/src/rocdecode/vaapi/vaapi_videodecoder.h
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.h
@@ -31,8 +31,10 @@ THE SOFTWARE.
 #include <cstring>
 #if __cplusplus >= 201703L && __has_include(<filesystem>)
     #include <filesystem>
+    namespace fs = std::filesystem;
 #else
     #include <experimental/filesystem>
+    namespace fs = std::experimental::filesystem;
 #endif
 #include <va/va.h>
 #include <va/va_drm.h>


### PR DESCRIPTION
This pull request addresses the "filesystem error: cannot increment recursive directory iterator: No such file or directory" issue that may occur on MI300 in the GetCurrentComputePartition function when reading the current partition mode.

In the GetCurrentComputePartition function, we look inside the `/sys/devices/` directory to find the `current_compute_partition` files and read the partition modes using std::filesystem::recursive_directory_iterator. However, exceptions may occur during the search from std::filesystem::recursive_directory_iterator if the content of the `/sys/devices/` changes. To handle this issue, we can use a try/catch block to catch any exceptions that arise during the search. If an exception occurs, we can ignore it and continue our search for the next entry until all the contents in the directory are searched.

I tested this PR on MI300A with SPX, TPX, and CPX modes with 100 processes on each available device without any issues.