### PR TITLE
Docs: reordered index grid (#345)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 .. meta::
   :description: rocDecode documentation and API reference library
-  :keywords: rocDecode, ROCm, API, documentation
+  :keywords: rocDecode, ROCm, API, documentation, video, decode, decoding, acceleration
 
 ********************************************************************
 rocDecode documentation
@@ -10,35 +10,41 @@ rocDecode provides APIs, utilities, and samples that you can use to easily acces
 features of your media engines (VCNs). It also allows interoperability with other compute engines on
 the GPU using Video Acceleration API (VA-API)/HIP. To learn more, see :doc:`what-is-rocDecode`
 
-You can access rocDecode code on the `GitHub repository <https://github.com/ROCm/rocDecode>`_.
+The code is open and hosted at `<https://github.com/ROCm/rocDecode>`_.
 
-The documentation is structured as follows:
 
 .. grid:: 2
   :gutter: 3
 
   .. grid-item-card:: Install
 
-    * :doc:`Quick-start <./install/quick-start>`
+    * :doc:`Quick start <./install/quick-start>`
     * :doc:`rocDecode installation <./install/install>`
 
-  .. grid-item-card:: API reference
 
-    * :doc:`API library <../doxygen/html/files>`
-    * :doc:`Functions <../doxygen/html/globals>`
-    * :doc:`Data structures <../doxygen/html/annotated>`
+The documentation is structured as follows:
 
-  .. grid-item-card:: How to
-
-    * :doc:`Use rocDecode <how-to/using-rocdecode>`
-
-  .. grid-item-card:: Conceptual
-
-     * :doc:`Video decoding pipeline <./conceptual/video-decoding-pipeline>`
+.. grid:: 2
+  :gutter: 3
 
   .. grid-item-card:: Tutorials
 
     * `GitHub samples <https://github.com/ROCm/rocDecode/tree/develop/samples>`_
+
+  .. grid-item-card:: How to
+
+    * :doc:`Using rocDecode <how-to/using-rocdecode>`
+
+  .. grid-item-card:: Conceptual
+
+     * :doc:`Video decoding pipeline <./conceptual/video-decoding-pipeline>`
+  
+  .. grid-item-card:: Reference
+
+    * :doc:`API library <../doxygen/html/files>`
+    * :doc:`Functions <../doxygen/html/globals>`
+    * :doc:`Data structures <../doxygen/html/annotated>`
+  
 
 To contribute to the documentation, refer to
 `Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -50,7 +50,7 @@ Prerequisites
   `amdgpu-install <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/amdgpu-install.html>`_
 
   * Run: ``--usecase=rocm``
-  * To install rocDecode with minimum requirements, follow the :doc:`quick-start instructions <./quick-start>`
+  * To install rocDecode with minimum requirements, follow the :doc:`quick start instructions <./quick-start>`
 
 * Video Acceleration API Version `1.5.0`+ - `Libva` is an implementation for VA-API
 
@@ -82,7 +82,11 @@ Prerequisites
 
     sudo apt install ffmpeg libavcodec-dev libavformat-dev libavutil-dev
 
-* If using Ubuntu 22.04, you must install ``libstdc++-12-dev``
+.. note::
+
+  * All package installs are shown with the ``apt`` package manager. Use the appropriate package manager for your operating system.
+
+  * On ``Ubuntu 22.04`` - Additional package required: ``libstdc++-12-dev``
 
   .. code:: shell
 

--- a/docs/install/quick-start.rst
+++ b/docs/install/quick-start.rst
@@ -3,7 +3,7 @@
   :keywords: install, rocDecode, AMD, ROCm
 
 ********************************************************************
-rocDecode quick-start installation
+rocDecode quick start installation
 ********************************************************************
 
 To install the rocDecode runtime with minimum requirements, follow these steps:

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -9,11 +9,26 @@ subtrees:
 - caption: Install
   entries:
   - file: install/quick-start.rst
-    title: Quick-start
+    title: Quick start
   - file: install/install.md
     title: Installation guide
 
-- caption: API reference
+- caption: Tutorials
+  entries:
+  - url: https://github.com/ROCm/rocDecode/tree/develop/samples
+    title: GitHub samples
+
+- caption: How to
+  entries:
+  - file: how-to/using-rocdecode.rst
+    title: Using rocDecode
+
+- caption: Conceptual
+  entries:
+  - file: conceptual/video-decoding-pipeline.rst
+    title: Video decoding pipeline
+
+- caption: Reference
   entries:
   - file: doxygen/html/files
     title: API library
@@ -21,21 +36,6 @@ subtrees:
     title: Functions
   - file: doxygen/html/annotated
     title: Data structures
-
-- caption: How to
-  entries:
-  - file: how-to/using-rocdecode.rst
-    title: Use rocDecode
-
-- caption: Conceptual
-  entries:
-  - file: conceptual/video-decoding-pipeline.rst
-    title: Video decoding pipeline
-
-- caption: Tutorials
-  entries:
-  - url: https://github.com/ROCm/rocDecode/tree/develop/samples
-    title: GitHub samples
 
 - caption: About
   entries:

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,1 @@
+Placeholder to ensure docs/tutorials folder is created.  Can remove once tutorial content is provided.


### PR DESCRIPTION
* reordered index to have separate install card, and diataxis grid

* add Tutorials folder

* Explain that tutorials/README.md is just a blank placeholder file.  Can be removed in future.

* Update docs/index.rst



* changed to quick start (no hyphen)

* missed index.rst for quick start edit

* change text to Using rocDecode

---------