### PR TITLE
Mariner - Support for package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,11 +197,12 @@ if(HIP_FOUND AND Libva_FOUND)
   file(READ "/etc/os-release" OS_RELEASE)
   string(REGEX MATCH "22.04" UBUNTU_22_FOUND ${OS_RELEASE})
   string(REGEX MATCH "SLES" SLES_FOUND ${OS_RELEASE})
+  string(REGEX MATCH "Mariner" MARINER_FOUND ${OS_RELEASE})
 
   # Set the dependent packages - TBD: mesa-amdgpu-va-drivers should bring libdrm-amdgpu, and parts of mesa-amdgpu-dri-drivers but unavailable on RPM
   set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva2, libdrm-amdgpu1, mesa-amdgpu-va-drivers")
   set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva, libdrm-amdgpu, mesa-amdgpu-va-drivers, mesa-amdgpu-dri-drivers")
-  if(SLES_FOUND)
+  if(SLES_FOUND OR MARINER_FOUND)
     set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva2, libdrm-amdgpu, mesa-amdgpu-va-drivers, mesa-amdgpu-dri-drivers")
   endif()
   # Set the dev dependent packages


### PR DESCRIPTION
Mariner packages updates
```
root [ ~ ]# cat /etc/lsb-release 
DISTRIB_ID="Mariner"
DISTRIB_RELEASE="2.0.20240609"
DISTRIB_CODENAME=Mariner
DISTRIB_DESCRIPTION="CBL-Mariner 2.0.20240609"
root [ ~ ]# yum install libva
Loaded plugin: tdnfrepogpgcheck
libva package not found or not installed
Error(1011) : No matching packages
root [ ~ ]# yum install libva2
Loaded plugin: tdnfrepogpgcheck
Package libva2 is already installed.
Nothing to do.
```