### PR TITLE
Setup - mariner build support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Documentation for rocDecode is available at
 ## Additions
 
 * FFMPEG V5.X Support
+* Mariner - Build Support
 
 ## Optimizations
 
@@ -36,7 +37,7 @@ Documentation for rocDecode is available at
 * mesa-amdgpu-va-drivers - `1:24.1.0`
 * mesa-amdgpu-dri-drivers - `24.1.0.60200`
 * FFmpeg - `4.2.7` / `4.4.2-0`
-* rocDecode Setup Script - `V2.0.0`
+* rocDecode Setup Script - `V2.1.0`
 
 ## rocDecode 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For your convenience, we provide the setup script, [rocDecode-setup.py](https://
 
 ```shell
 python3 rocDecode-setup.py  --rocm_path [ ROCm Installation Path  - optional (default:/opt/rocm)]
+                            --runtime   [ Setup runtime requirements - optional (default:ON) [options:ON/OFF]]
                             --developer [ Setup Developer Options - optional (default:OFF) [options:ON/OFF]]
 ```
 
@@ -234,4 +235,4 @@ page.
 * mesa-amdgpu-va-drivers - `1:24.1.0`
 * mesa-amdgpu-dri-drivers - `24.1.0.60200`
 * FFmpeg - `4.2.7` / `4.4.2-0`
-* rocDecode Setup Script - `V2.0.0`
+* rocDecode Setup Script - `V2.1.0`

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -29,7 +29,7 @@ else:
     import subprocess
 
 __copyright__ = "Copyright (c) 2023 - 2024, AMD ROCm rocDecode"
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __email__ = "mivisionx.support@amd.com"
 __status__ = "Shipping"
 
@@ -45,10 +45,13 @@ def ERROR_CHECK(call):
 parser = argparse.ArgumentParser()
 parser.add_argument('--rocm_path', 	type=str, default='/opt/rocm',
                     help='ROCm Installation Path - optional (default:/opt/rocm) - ROCm Installation Required')
+parser.add_argument('--runtime', 	type=str, default='ON',
+                    help='Install RunTime Dependencies - optional (default:ON) [options:ON/OFF]')
 parser.add_argument('--developer', 	type=str, default='OFF',
                     help='Setup Developer Options - optional (default:OFF) [options:ON/OFF]')
 
 args = parser.parse_args()
+runtimeInstall = args.runtime.upper()
 developerInstall = args.developer.upper()
 
 ROCM_PATH = args.rocm_path
@@ -70,6 +73,10 @@ else:
 if developerInstall not in ('OFF', 'ON'):
     print(
         "ERROR: Developer Option Not Supported - [Supported Options: OFF or ON]\n")
+    exit()
+if runtimeInstall not in ('OFF', 'ON'):
+    print(
+        "ERROR: Runtime Option Not Supported - [Supported Options: OFF or ON]\n")
     exit()
 
 # get platfrom info
@@ -132,6 +139,7 @@ elif "Mariner" in os_info_data:
     linuxSystemInstall = 'tdnf -y'
     linuxSystemInstall_check = '--nogpgcheck'
     platfromInfo = platfromInfo+'-Mariner'
+    runtimeInstall = 'OFF'
 else:
     print("\nrocDecode Setup on "+platfromInfo+" is unsupported\n")
     print("\nrocDecode Setup Supported on: Ubuntu 20/22, RedHat 8/9, & SLES 15\n")
@@ -206,7 +214,7 @@ for i in range(len(commonPackages)):
     ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
             ' '+linuxSystemInstall_check+' install '+ commonPackages[i]))
 
-# rocDecode Core - LibVA Requirements
+# rocDecode Core - Requirements
 ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 if "Ubuntu" in platfromInfo:
     for i in range(len(coreDebianPackages)):
@@ -221,7 +229,19 @@ else:
         ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
                 ' '+linuxSystemInstall_check+' install '+ coreRPMPackages[i]))
 
-# rocDecode Dev Requirements
+# rocDecode runTime - Requirements
+ERROR_CHECK(os.system('sudo '+sudoValidateOption))
+if runtimeInstall == 'ON':
+    if "Ubuntu" in platfromInfo:
+        for i in range(len(runtimeDebianPackages)):
+            ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                ' '+linuxSystemInstall_check+' install '+ runtimeDebianPackages[i]))
+    else:
+        for i in range(len(runtimeRPMPackages)):
+            ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                ' '+linuxSystemInstall_check+' install '+ runtimeRPMPackages[i]))
+
+# rocDecode Dev - Requirements
 ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 if developerInstall == 'ON':
     if "Ubuntu" in platfromInfo:

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -161,12 +161,14 @@ coreDebianPackages = [
     'rocm-hip-runtime-dev',
     'libva2',
     'libva-dev',
-    'libdrm-amdgpu1',
-    'mesa-amdgpu-va-drivers',
-    'vainfo'
 ]
 coreDebianU22Packages = [
     'libstdc++-12-dev'
+]
+runtimeDebianPackages = [
+    'libdrm-amdgpu1',
+    'mesa-amdgpu-va-drivers',
+    'vainfo'
 ]
 ffmpegDebianPackages = [
     'ffmpeg',
@@ -177,15 +179,18 @@ ffmpegDebianPackages = [
 
 # RPM Packages
 libvaNameRPM = "libva"
-libvaUtilsNameRPM = "libva-utils"
 if "SLES" in os_info_data or "Mariner" in os_info_data:
     libvaNameRPM = "libva2"
-if "Mariner" in os_info_data:
-    libvaUtilsNameRPM = "libva2" #TBD - no utils package available 
 coreRPMPackages = [
     'rocm-hip-runtime-devel',
     str(libvaNameRPM),
-    'libva-devel',
+    'libva-devel'
+]
+
+libvaUtilsNameRPM = "libva-utils"
+if "Mariner" in os_info_data:
+    libvaUtilsNameRPM = "libva2" #TBD - no utils package available 
+runtimeRPMPackages = [
     'libdrm-amdgpu',
     'mesa-amdgpu-va-drivers',
     'mesa-amdgpu-dri-drivers',

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -153,7 +153,6 @@ commonPackages = [
     'wget',
     'unzip',
     'pkg-config',
-    'inxi',
     'rocm-hip-runtime'
 ]
 

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -100,7 +100,7 @@ linuxCMake = 'cmake'
 linuxSystemInstall_check = ''
 linuxFlag = ''
 sudoValidateOption= '-v'
-if "centos" in os_info_data or "redhat" in os_info_data or os.path.exists('/usr/bin/yum'):
+if "centos" in os_info_data or "redhat" in os_info_data:
     linuxSystemInstall = 'yum -y'
     linuxSystemInstall_check = '--nogpgcheck'
     if "VERSION_ID=7" in os_info_data:
@@ -112,7 +112,7 @@ if "centos" in os_info_data or "redhat" in os_info_data or os.path.exists('/usr/
         platfromInfo = platfromInfo+'-redhat-9'
     else:
         platfromInfo = platfromInfo+'-redhat-centos-undefined-version'
-elif "Ubuntu" in os_info_data or os.path.exists('/usr/bin/apt-get'):
+elif "Ubuntu" in os_info_data:
     linuxSystemInstall = 'apt-get -y'
     linuxSystemInstall_check = '--allow-unauthenticated'
     linuxFlag = '-S'
@@ -124,11 +124,11 @@ elif "Ubuntu" in os_info_data or os.path.exists('/usr/bin/apt-get'):
         platfromInfo = platfromInfo+'-Ubuntu-24'
     else:
         platfromInfo = platfromInfo+'-Ubuntu-undefined-version'
-elif "SLES" in os_info_data or os.path.exists('/usr/bin/zypper'):
+elif "SLES" in os_info_data:
     linuxSystemInstall = 'zypper -n'
     linuxSystemInstall_check = '--no-gpg-checks'
     platfromInfo = platfromInfo+'-SLES'
-elif "Mariner" in os_info_data or os.path.exists('/usr/bin/tdnf'):
+elif "Mariner" in os_info_data:
     linuxSystemInstall = 'tdnf -y'
     linuxSystemInstall_check = '--nogpgcheck'
     platfromInfo = platfromInfo+'-Mariner'

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -128,6 +128,10 @@ elif "SLES" in os_info_data or os.path.exists('/usr/bin/zypper'):
     linuxSystemInstall = 'zypper -n'
     linuxSystemInstall_check = '--no-gpg-checks'
     platfromInfo = platfromInfo+'-SLES'
+elif "Mariner" in os_info_data or os.path.exists('/usr/bin/tdnf'):
+    linuxSystemInstall = 'tdnf -y'
+    linuxSystemInstall_check = '--nogpgcheck'
+    platfromInfo = platfromInfo+'-Mariner'
 else:
     print("\nrocDecode Setup on "+platfromInfo+" is unsupported\n")
     print("\nrocDecode Setup Supported on: Ubuntu 20/22, RedHat 8/9, & SLES 15\n")
@@ -174,8 +178,11 @@ ffmpegDebianPackages = [
 
 # RPM Packages
 libvaNameRPM = "libva"
-if os.path.exists('/usr/bin/zypper'):
-        libvaNameRPM = "libva2"
+libvaUtilsNameRPM = "libva-utils"
+if "SLES" in os_info_data or "Mariner" in os_info_data:
+    libvaNameRPM = "libva2"
+if "Mariner" in os_info_data:
+    libvaUtilsNameRPM = "libva2" #TBD - no utils package available 
 coreRPMPackages = [
     'rocm-hip-runtime-devel',
     str(libvaNameRPM),
@@ -183,7 +190,7 @@ coreRPMPackages = [
     'libdrm-amdgpu',
     'mesa-amdgpu-va-drivers',
     'mesa-amdgpu-dri-drivers',
-    'libva-utils'
+    str(libvaUtilsNameRPM)
 ]
 
 # update


### PR DESCRIPTION
```
rocDecode Setup on: Linux-5.15.0-107-generic-x86_64-with-glibc2.35-Mariner


rocDecode Dependencies Installation with rocDecode-setup.py V-2.1.0

Loaded plugin: tdnfrepogpgcheck
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package gcc is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package cmake is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package git is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package wget is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package unzip is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
[using capability match for 'pkg-config']
[using capability match for 'pkg-config']
Package pkg-config is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package rocm-hip-runtime is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package rocm-hip-runtime-devel is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package libva2 is already installed.
Nothing to do.
Loaded plugin: tdnfrepogpgcheck
Package libva-devel is already installed.
Nothing to do.

rocDecode Dependencies Installed with rocDecode-setup.py V-2.1.0
```