### PR TITLE
Fixed bug with videoDecodeBatch

### DIFF
--- a/samples/videoDecodeBatch/videodecodebatch.cpp
+++ b/samples/videoDecodeBatch/videodecodebatch.cpp
@@ -125,9 +125,11 @@ void DecProc(RocVideoDecoder *p_dec, VideoDemuxer *demuxer, int *pn_frame, doubl
         n_frame_returned = p_dec->DecodeFrame(p_video, n_video_bytes, 0, pts);
         n_frame += n_frame_returned;
         if (b_dump_output_frames && mem_type != OUT_SURFACE_MEM_NOT_MAPPED) {
-            if (!n_frame && !p_dec->GetOutputSurfaceInfo(&surf_info)) {
-                std::cerr << "Error: Failed to get Output Surface Info!" << std::endl;
-                break;
+            if(n_frame){
+                if(!p_dec->GetOutputSurfaceInfo(&surf_info)){
+                    std::cerr << "Error: Failed to get Output Surface Info!" << std::endl;
+                    break;
+                }
             }
             for (int i = 0; i < n_frame_returned; i++) {
                 p_frame = p_dec->GetFrame(&pts);

--- a/samples/videoDecodeBatch/videodecodebatch.cpp
+++ b/samples/videoDecodeBatch/videodecodebatch.cpp
@@ -125,8 +125,8 @@ void DecProc(RocVideoDecoder *p_dec, VideoDemuxer *demuxer, int *pn_frame, doubl
         n_frame_returned = p_dec->DecodeFrame(p_video, n_video_bytes, 0, pts);
         n_frame += n_frame_returned;
         if (b_dump_output_frames && mem_type != OUT_SURFACE_MEM_NOT_MAPPED) {
-            if(n_frame){
-                if(!p_dec->GetOutputSurfaceInfo(&surf_info)){
+            if (n_frame_returned) {
+                if (!p_dec->GetOutputSurfaceInfo(&surf_info)) {
                     std::cerr << "Error: Failed to get Output Surface Info!" << std::endl;
                     break;
                 }


### PR DESCRIPTION
Fixed the bug where some output streams were 0 bytes. Also fixes bug where some output streams are an order of magnitude larger in size than they should be.
Original code:
`if (!n_frame && !p_dec->GetOutputSurfaceInfo(&surf_info)) {
                std::cerr << "Error: Failed to get Output Surface Info!" << std::endl;
                break;
 }`

This evaluates as false if n_frame doesn't return false or if surf_info is not false. So both need to be false to throw the error, otherwise it goes through. 
Code is changed to:
`if(n_frame){
      if(!p_dec->GetOutputSurfaceInfo(&surf_info)){
             std::cerr << "Error: Failed to get Output Surface Info!" << std::endl;
             break;
     }
}`
Now if n_frame evaluates to true but surf_info does not it throws the error, which should be the correct behavior.
