### PR TITLE
AV1: Basic inter decode is up and running.

### DIFF
--- a/src/parser/av1_defines.h
+++ b/src/parser/av1_defines.h
@@ -42,9 +42,9 @@ THE SOFTWARE.
 
 #define NUM_REF_FRAMES 8
 #define PRIMARY_REF_NONE 7
-
 #define REFS_PER_FRAME 7  // Number of reference frames that can be used for inter prediction
 #define TOTAL_REFS_PER_FRAME 8  // Number of reference frame types (including intra type)
+#define BUFFER_POOL_MAX_SIZE 10 // Number of frames in buffer pool
 
 #define MAX_TILE_WIDTH 4096  // Maximum width of a tile in units of luma samples
 #define MAX_TILE_AREA 4096 * 2304  // Maximum area of a tile in units of luma samples


### PR DESCRIPTION
 - Added initial support for DPB and decode/display buffer management.
 - Added initial display support.
 - Added reference frame set up.
 - Fixed an issue with cdef_y_sec_strength/cdef_uv_sec_strength parsing. We should leave the conditional increment to VA-API driver or below due to VA-API formatting.