### PR TITLE
Fix mesa dependency on older SLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,10 @@ if(HIP_FOUND AND Libva_FOUND)
   # Set the dependent packages - TBD: mesa-amdgpu-va-drivers should bring libdrm-amdgpu, and parts of mesa-amdgpu-dri-drivers but unavailable on RPM
   set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva2, libdrm-amdgpu1, mesa-amdgpu-va-drivers")
   set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva, libdrm-amdgpu, mesa-amdgpu-va-drivers, mesa-amdgpu-dri-drivers")
-  if(SLES_FOUND OR MARINER_FOUND)
+  if(SLES_FOUND)
+    set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva2, libdrm-amdgpu, (mesa-amdgpu-va-drivers or mesa-amdgpu-dri-drivers or Mesa-libva)")
+  endif()
+  if(MARINER_FOUND)
     set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva2, libdrm-amdgpu, mesa-amdgpu-va-drivers, mesa-amdgpu-dri-drivers")
   endif()
   # Set the dev dependent packages


### PR DESCRIPTION
We don't build mesa for older SLE, so we should allow it to fall back to the distro provided package if it's unavailable.

Some caveats/notes:
- Distro mesa is often older, which doesn't have newer HW support... this patch might have zypper consider the two dependencies as of equal value, rather than the mesa-amdgpu as better. I don't think there's a way to do this with the default configuration of zypper
- Mariner also has this issue, as the OS vendor prefers to build mesa, but I don't know the package name yet as they haven't enabled the va drivers in their mesa yet
- I don't know if this is a temporary workaround for SLE yet, but we need this cherry-picked into 6.2 if accepted at the very least