### PR TITLE
Update formatting in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 Documentation for rocDecode is available at
 [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
-## rocDecode 0.6.0 (Unreleased)
+## rocDecode 0.6.0
 
-## Additions
+### Additions
 
 * FFMPEG V5.X Support
 * Mariner - Build Support
 
-## Optimizations
+### Optimizations
 
 * Setup Script - Error Check install
 


### PR DESCRIPTION
Autotag script expects different header levels for scraping changelogs

ie: 1 for top level, 2 for each version, 3 for notes (additions, changes, etc.)