### PR TITLE
AV1: Added a few changes to enable general testing (non-film-grain).

### DIFF
--- a/src/parser/av1_defines.h
+++ b/src/parser/av1_defines.h
@@ -298,7 +298,7 @@ typedef struct {
     uint32_t segmentation_temporal_update;
     uint32_t segmentation_update_data;
     uint32_t feature_enabled;
-    uint32_t feature_enabled_flags[MAX_SEGMENTS][SEG_LVL_MAX];
+    uint8_t  feature_enabled_flags[MAX_SEGMENTS][SEG_LVL_MAX];
     uint32_t feature_value;
     int16_t  feature_data[MAX_SEGMENTS][SEG_LVL_MAX];
     uint32_t seg_id_pre_skip;
@@ -322,9 +322,9 @@ typedef struct {
     uint32_t loop_filter_delta_enabled;
     uint32_t loop_filter_delta_update;
     uint32_t update_ref_delta;
-    uint32_t loop_filter_ref_deltas[TOTAL_REFS_PER_FRAME];
+    int32_t  loop_filter_ref_deltas[TOTAL_REFS_PER_FRAME];
     uint32_t update_mode_delta;
-    uint32_t loop_filter_mode_deltas[2];
+    int32_t  loop_filter_mode_deltas[2];
 } Av1LoopFilterParams;
 
 typedef struct {

--- a/src/parser/av1_parser.cpp
+++ b/src/parser/av1_parser.cpp
@@ -124,8 +124,7 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
             case kObuTileGroup: {
                 ParseTileGroupObu(pic_data_buffer_ptr_ + obu_byte_offset_, obu_size_);
                 break;
-                    pic_count_++;
-    }
+            }
             default:
                 break;
         }


### PR DESCRIPTION
 - Added show existing frame support.
 - Added load_previous() function.
 - Added more operations to reference frame update process.
 - Added reference frame loading process.
 - Added decode frame wrap up process.
 - Added DPB recycling.
 - Added DPB content logging funciton for debugging purposes.