### PR TITLE
AV1: Added support for film grain synthesis and several other fixes.

### DIFF
--- a/src/parser/av1_parser.h
+++ b/src/parser/av1_parser.h
@@ -68,13 +68,14 @@ public:
         uint32_t num_tiles;
         uint32_t tg_start; // tg_start of the current tile group
         uint32_t tg_end; // tg_end of the current tile group
-        uint32_t tile_number; // current tile number (counting from 0 to num_tiles - 1)
+        uint32_t num_tiles_parsed; // number of parsed tiles for the current frame
         Av1TileDataInfo tile_data_info[MAX_TILE_ROWS * MAX_TILE_COLS];
     } Av1TileGroupDataInfo;
 
     typedef struct {
         int      pic_idx;
-        int      dec_buf_idx;  // frame index in decode buffer pool
+        int      dec_buf_idx;  // frame index in decode/display buffer pool
+        int      fg_buf_idx;  // frame index for film grain synthesis output in decode/display buffer pool
         uint32_t current_frame_id;
         uint32_t order_hint;
         uint32_t frame_type;
@@ -101,6 +102,7 @@ public:
         int32_t saved_loop_filter_mode_deltas[NUM_REF_FRAMES][2];
         uint8_t saved_feature_enabled[NUM_REF_FRAMES][MAX_SEGMENTS][SEG_LVL_MAX];
         int16_t saved_feature_data[NUM_REF_FRAMES][MAX_SEGMENTS][SEG_LVL_MAX];
+        Av1FilmGrainParams saved_film_grain_params[NUM_REF_FRAMES];
     } DecodedPictureBuffer;
 
 protected:

--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -173,18 +173,26 @@ rocDecStatus VaapiVideoDecoder::CreateSurfaces() {
         return ROCDEC_INVALID_PARAMETER;
     }
     va_surface_ids_.resize(decoder_create_info_.num_decode_surfaces);
+    VASurfaceAttrib surf_attrib;
+    surf_attrib.type = VASurfaceAttribPixelFormat;
+    surf_attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
+    surf_attrib.value.type = VAGenericValueTypeInteger;
     uint32_t surface_format;
     switch (decoder_create_info_.chroma_format) {
         case rocDecVideoChromaFormat_Monochrome:
             surface_format = VA_RT_FORMAT_YUV400;
+            surf_attrib.value.value.i = VA_FOURCC_Y800;
             break;
         case rocDecVideoChromaFormat_420:
             if (decoder_create_info_.bit_depth_minus_8 == 2) {
                 surface_format = VA_RT_FORMAT_YUV420_10;
+                surf_attrib.value.value.i = VA_FOURCC_P010;
             } else if (decoder_create_info_.bit_depth_minus_8 == 4) {
                 surface_format = VA_RT_FORMAT_YUV420_12;
+                surf_attrib.value.value.i = VA_FOURCC_P012;
             } else {
                 surface_format = VA_RT_FORMAT_YUV420;
+                surf_attrib.value.value.i = VA_FOURCC_NV12;
             }
             break;
         case rocDecVideoChromaFormat_422:
@@ -197,10 +205,8 @@ rocDecStatus VaapiVideoDecoder::CreateSurfaces() {
             ERR("The surface type is not supported");
             return ROCDEC_NOT_SUPPORTED;
     }
-
     CHECK_VAAPI(vaCreateSurfaces(va_display_, surface_format, decoder_create_info_.width,
-        decoder_create_info_.height, va_surface_ids_.data(), va_surface_ids_.size(), nullptr, 0));
-
+        decoder_create_info_.height, va_surface_ids_.data(), va_surface_ids_.size(), &surf_attrib, 1));
     return ROCDEC_SUCCESS;
 }
 


### PR DESCRIPTION
 - Added film grain parameter saving and loading procedures.
 - Added buffer management for film grain synthesis output.
 - Fixed the corruption issue with 10-bit film grain streams. We need to set surface attributes based on pixel format when creating VAAPI surfaces.
 - Added missing global motion, loop filter and segmentation parameter loading in load reference frame procedure.
 - Fixed an issue with one tile streams.
 - Fixed an issue with uninitialised frame header structure after frame decode.
 - Fixed a bug with decode buffer status update.