### PR TITLE
Add versioning file for rocdecode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ if(HIP_FOUND AND Libva_FOUND)
   install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev NAMELINK_ONLY)
   install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT asan)
   # install rocDecode include files -- {ROCM_PATH}/include/rocdecode
-  install(FILES api/rocdecode.h api/rocparser.h
+  install(FILES api/rocdecode.h api/rocparser.h api/rocdecode_version.h
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME} COMPONENT dev)
   # install rocDecode samples -- {ROCM_PATH}/share/rocdecode
   install(DIRECTORY cmake DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME} COMPONENT dev)

--- a/api/rocdecode.h
+++ b/api/rocdecode.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 
 #pragma once
 #include "hip/hip_runtime.h"
+#include "rocdecode_version.h"
 
 /*!
  * \file

--- a/api/rocdecode_version.h
+++ b/api/rocdecode_version.h
@@ -37,6 +37,16 @@ extern "C" {
 #define ROCDECODE_MINOR_VERSION 7
 #define ROCDECODE_MICRO_VERSION 0
 
+
+/**
+ * ROCDECODE_CHECK_VERSION:
+ * @major: major version, like 1 in 1.2.3
+ * @minor: minor version, like 2 in 1.2.3
+ * @micro: micro version, like 3 in 1.2.3
+ *
+ * Evaluates to %TRUE if the version of rocDecode is greater than
+ * @major, @minor and @micro
+ */
 #define ROCDECODE_CHECK_VERSION(major, minor, micro) \
         (ROCDECODE_MAJOR_VERSION > (major) || \
         (ROCDECODE_MAJOR_VERSION == (major) && ROCDECODE_MINOR_VERSION > (minor)) || \

--- a/api/rocdecode_version.h
+++ b/api/rocdecode_version.h
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2024 - 2024 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef ROCDECODE_VERSION_H
+#define ROCDECODE_VERSION_H
+
+/*!
+ * \file
+ * \brief rocDecode version
+ * \defgroup group_rocdecode_version rocDecode Version
+ * \brief rocDecode version
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define ROCDECODE_MAJOR_VERSION 0
+#define ROCDECODE_MINOR_VERSION 7
+#define ROCDECODE_MICRO_VERSION 0
+
+#define ROCDECODE_CHECK_VERSION(major, minor, micro) \
+        (ROCDECODE_MAJOR_VERSION > (major) || \
+        (ROCDECODE_MAJOR_VERSION == (major) && ROCDECODE_MINOR_VERSION > (minor)) || \
+        (ROCDECODE_MAJOR_VERSION == (major) && ROCDECODE_MINOR_VERSION == (minor) && ROCDECODE_MICRO_VERSION >= (micro)))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Adds a version file for rocDecode. Need this information in other projects. Merge after #391. Using version number 0.7.0, following the PR. 