### PR TITLE
Fix a compilation issue in RHEL8

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -156,7 +156,7 @@ rocDecStatus VaapiVideoDecoder::CreateDecoderConfig() {
 #if VA_CHECK_VERSION(1,6,0)
             va_profile_ = VAProfileAV1Profile0;
 #else
-            va_profile_ = 32; // VAProfileAV1Profile0;
+            va_profile_ = static_cast<VAProfile>(32); // VAProfileAV1Profile0;
 #endif
             break;
         default:


### PR DESCRIPTION
With this change, we can compile rocDecode and decode AV1 in RHEL8.

bash-4.4# rpm -qa | grep release
redhat-release-8.8-0.8.el8.x86_64
epel-release-8-20.el8.noarch

bash-4.4# ./videodecode -i /dockerx/AMD_driving_virtual_20-AV1.mp4 
info: Input file: AMD_driving_virtual_20-AV1.mp4
info: Using GPU device 0 - AMD Radeon RX 6750 XT[gfx1031] on PCI bus 0b:00.0
info: decoding started, please wait!
Input Video Information
        Codec        : AV1
        Sequence     : Progressive
        Coded size   : [2048, 1024]
        Display area : [0, 0, 2048, 1024]
        Chroma       : YUV 420
        Bit depth    : 8
Video Decoding Params:
        Num Surfaces : 12
        Crop         : [0, 0, 2048, 1024]
        Resize       : 2048x1024

info: Total frame decoded: 601
info: avg decoding time per frame: 1.96673 ms
info: avg FPS: 508.457