### PR TITLE
Added the missing presentation time stamp (pts) to decode return info for displayed pictures.

### DIFF
--- a/src/parser/av1_parser.cpp
+++ b/src/parser/av1_parser.cpp
@@ -52,6 +52,7 @@ rocDecStatus Av1VideoParser::UnInitialize() {
 
 rocDecStatus Av1VideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) { 
     if (p_data->payload && p_data->payload_size) {
+        curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
             ERR(STR("Parser failed!"));
             return ROCDEC_RUNTIME_ERROR;
@@ -151,6 +152,7 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                     disp_idx = dpb_buffer_.frame_store[disp_idx].dec_buf_idx;
                 }
                 decode_buffer_pool_[disp_idx].use_status |= kFrameUsedForDisplay;
+                decode_buffer_pool_[disp_idx].pts = curr_pts_;
                 // Insert into output/display picture list
                 if (num_output_pics_ >= dec_buf_pool_size_) {
                     ERR("Display list size larger than decode buffer pool size!");
@@ -612,6 +614,7 @@ ParserResult Av1VideoParser::FindFreeInDecBufPool() {
     curr_pic_.dec_buf_idx = dec_buf_index;
     decode_buffer_pool_[dec_buf_index].use_status |= kFrameUsedForDecode;
     decode_buffer_pool_[dec_buf_index].pic_order_cnt = curr_pic_.order_hint;
+    decode_buffer_pool_[dec_buf_index].pts = curr_pts_;
     // Find a free buffer in decode/display buffer pool to store FG output
     if (seq_header_.film_grain_params_present && frame_header_.film_grain_params.apply_grain) {
         for (dec_buf_index = 0; dec_buf_index < dec_buf_pool_size_; dec_buf_index++) {
@@ -626,6 +629,7 @@ ParserResult Av1VideoParser::FindFreeInDecBufPool() {
         curr_pic_.fg_buf_idx = dec_buf_index;
         decode_buffer_pool_[dec_buf_index].use_status |= kFrameUsedForDisplay;
         decode_buffer_pool_[dec_buf_index].pic_order_cnt = curr_pic_.order_hint;
+        decode_buffer_pool_[dec_buf_index].pts = curr_pts_;
     } else {
         curr_pic_.fg_buf_idx = curr_pic_.dec_buf_idx;
     }
@@ -656,6 +660,7 @@ ParserResult Av1VideoParser::FindFreeInDpbAndMark() {
             disp_idx = curr_pic_.dec_buf_idx;
         }
         decode_buffer_pool_[disp_idx].use_status |= kFrameUsedForDisplay;
+        decode_buffer_pool_[disp_idx].pts = curr_pts_;
         // Insert into output/display picture list
         if (num_output_pics_ >= dec_buf_pool_size_) {
             ERR("Display list size larger than decode buffer pool size!");
@@ -2670,7 +2675,7 @@ void Av1VideoParser::PrintDpb() {
     MSG("Decode buffer pool:");
     for(i = 0; i < dec_buf_pool_size_; i++) {
         DecodeFrameBuffer *p_dec_buf = &decode_buffer_pool_[i];
-        MSG("Decode buffer " << i << ": use_status = " << p_dec_buf->use_status << ", pic_order_cnt = " << p_dec_buf->pic_order_cnt);
+        MSG("Decode buffer " << i << ": use_status = " << p_dec_buf->use_status << ", pic_order_cnt = " << p_dec_buf->pic_order_cnt << ", pts = " << p_dec_buf->pts);
     }
     MSG("num_output_pics_ = " << num_output_pics_);
     if (num_output_pics_) {

--- a/src/parser/avc_parser.cpp
+++ b/src/parser/avc_parser.cpp
@@ -63,6 +63,7 @@ rocDecStatus AvcVideoParser::UnInitialize() {
 
 rocDecStatus AvcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     if (p_data->payload && p_data->payload_size) {
+        curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
             ERR(STR("Parser failed!"));
             return ROCDEC_RUNTIME_ERROR;
@@ -3110,6 +3111,7 @@ ParserResult AvcVideoParser::InsertCurrPicIntoDpb() {
             decode_buffer_pool_[curr_pic_.dec_buf_idx].use_status |= kFrameUsedForDisplay;
         }
         decode_buffer_pool_[curr_pic_.dec_buf_idx].pic_order_cnt = curr_pic_.pic_order_cnt;
+        decode_buffer_pool_[curr_pic_.dec_buf_idx].pts = curr_pts_;
     } else {
         ERR("Could not find the reserved frame buffer for the current picture in DPB.");
         return PARSER_FAIL;
@@ -3396,7 +3398,7 @@ void AvcVideoParser::PrintDpb() {
     MSG("Decode buffer pool:");
     for(i = 0; i < dec_buf_pool_size_; i++) {
         DecodeFrameBuffer *p_dec_buf = &decode_buffer_pool_[i];
-        MSG("Decode buffer " << i << ": use_status = " << p_dec_buf->use_status << ", pic_order_cnt = " << p_dec_buf->pic_order_cnt);
+        MSG("Decode buffer " << i << ": use_status = " << p_dec_buf->use_status << ", pic_order_cnt = " << p_dec_buf->pic_order_cnt << ", pts = " << p_dec_buf->pts);
     }
     MSG("num_output_pics_ = " << num_output_pics_);
     if (num_output_pics_) {

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -78,6 +78,7 @@ rocDecStatus HevcVideoParser::UnInitialize() {
 
 rocDecStatus HevcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     if (p_data->payload && p_data->payload_size) {
+        curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
             ERR(STR("Parser failed!"));
             return ROCDEC_RUNTIME_ERROR;
@@ -2289,6 +2290,7 @@ ParserResult HevcVideoParser::FindFreeInDpbAndMark() {
         decode_buffer_pool_[curr_pic_info_.dec_buf_idx].use_status |= kFrameUsedForDisplay;
     }
     decode_buffer_pool_[curr_pic_info_.dec_buf_idx].pic_order_cnt = curr_pic_info_.pic_order_cnt;
+    decode_buffer_pool_[curr_pic_info_.dec_buf_idx].pts = curr_pts_;
 
     HevcSeqParamSet *sps_ptr = &m_sps_[m_active_sps_id_];
     uint32_t highest_tid = sps_ptr->sps_max_sub_layers_minus1; // HighestTid
@@ -2763,7 +2765,7 @@ void HevcVideoParser::PrintDpb() {
     MSG("Decode buffer pool:");
     for(i = 0; i < dec_buf_pool_size_; i++) {
         DecodeFrameBuffer *p_dec_buf = &decode_buffer_pool_[i];
-        MSG("Decode buffer " << i << ": use_status = " << p_dec_buf->use_status << ", pic_order_cnt = " << p_dec_buf->pic_order_cnt);
+        MSG("Decode buffer " << i << ": use_status = " << p_dec_buf->use_status << ", pic_order_cnt = " << p_dec_buf->pic_order_cnt << ", pts = " << p_dec_buf->pts);
     }
     MSG("num_output_pics_ = " << num_output_pics_);
     if (num_output_pics_) {

--- a/src/parser/roc_video_parser.cpp
+++ b/src/parser/roc_video_parser.cpp
@@ -29,6 +29,7 @@ RocVideoParser::RocVideoParser() {
     new_seq_activated_ = false;
     frame_rate_.numerator = 0;
     frame_rate_.denominator = 0;
+    curr_pts_ = 0;
 
     sei_rbsp_buf_ = nullptr;
     sei_rbsp_buf_size_ = 0;
@@ -101,6 +102,7 @@ ParserResult RocVideoParser::OutputDecodedPictures(bool no_delay) {
         int num_disp = num_output_pics_ - disp_delay;
         for (int i = 0; i < num_disp; i++) {
             disp_info.picture_index = output_pic_list_[i];
+            disp_info.pts = decode_buffer_pool_[output_pic_list_[i]].pts;
             pfn_display_picture_cb_(parser_params_.user_data, &disp_info);
             decode_buffer_pool_[output_pic_list_[i]].use_status &= ~kFrameUsedForDisplay;
         }

--- a/src/parser/roc_video_parser.h
+++ b/src/parser/roc_video_parser.h
@@ -122,6 +122,7 @@ protected:
     typedef struct {
         uint32_t use_status;    // refer to FrameBufUseStatus
         uint32_t pic_order_cnt;
+        RocdecTimeStamp pts;
     } DecodeFrameBuffer;
     uint32_t dec_buf_pool_size_;        /* Number of decoded frame surfaces in the pool which are recycled. The size should be greater
                                            than or equal to DPB size (normally greater to guarantee smooth operations). The value is
@@ -133,6 +134,7 @@ protected:
     uint32_t num_output_pics_;  // number of pictures that are ready to be ouput
     std::vector<uint32_t> output_pic_list_; // sorted output frame index to decode_buffer_pool_
 
+    RocdecTimeStamp curr_pts_;
     Rational frame_rate_;
 
     RocdecVideoFormat video_format_params_;


### PR DESCRIPTION
- This is to address issue #386: RocDecode Parser: Not returning timestamps with output frame.