### PR TITLE
Perf sample: Added decoded frame number and display delay options to video decode performance sample. 

### DIFF
--- a/samples/videoDecodePerf/README.md
+++ b/samples/videoDecodePerf/README.md
@@ -30,7 +30,9 @@ make -j
 
 ```shell
 ./videodecodeperf -i <input video file [required]> 
-                  -t <number of threads [optional - default:4]>
+                  -t <number of threads [optional - default:1]>
+                  -f <Number of decoded frames - specify the number of pictures to be decoded [optional]>
+                  -disp_delay <display delay - specify the number of frames to be delayed for display [optional]>
                   -d <Device ID (>= 0) [optional - default:0]>
                   -z <force_zero_latency - Decoded frames will be flushed out for display immediately [optional]>
 ```

--- a/test/testScripts/README.md
+++ b/test/testScripts/README.md
@@ -43,7 +43,7 @@ optional arguments:
   --sample_mode SAMPLE_MODE
                         The sample to run - optional (default:0 [range:0-1] 0: videoDecode, 1: videoDecodePerf)
   --num_threads NUM_THREADS
-                        The number of threads is only for the videoDecodePerf sample (sample_mode = 1) - optional (default:4)
+                        The number of threads is only for the videoDecodePerf sample (sample_mode = 1) - optional (default:1)
   --max_num_decoded_frames MAX_NUM_DECODED_FRAMES
                         The max number of decoded frames. Useful for partial decoding of a long stream. - optional (default:0, meaning no limit)
 ```

--- a/test/testScripts/README.md
+++ b/test/testScripts/README.md
@@ -44,6 +44,8 @@ optional arguments:
                         The sample to run - optional (default:0 [range:0-1] 0: videoDecode, 1: videoDecodePerf)
   --num_threads NUM_THREADS
                         The number of threads is only for the videoDecodePerf sample (sample_mode = 1) - optional (default:4)
+  --max_num_decoded_frames MAX_NUM_DECODED_FRAMES
+                        The max number of decoded frames. Useful for partial decoding of a long stream. - optional (default:0, meaning no limit)
 ```
 
 * **run_rocDecode_Conformance.py**

--- a/test/testScripts/run_rocDecodeSamples.py
+++ b/test/testScripts/run_rocDecodeSamples.py
@@ -64,8 +64,10 @@ parser.add_argument('--files_directory',    type=str, default='',
                     help='The path to a dirctory containing one or more supported files for decoding (e.g., mp4, mov, etc.) - required')
 parser.add_argument('--sample_mode',          type=int, default=0,
                     help='The sample to run - optional (default:0 [range:0-1] 0: videoDecode, 1: videoDecodePerf)')
-parser.add_argument('--num_threads',          type=int, default=4,
-                    help='The number of threads is only for the videoDecodePerf sample (sample_mode = 1) - optional (default:4)')
+parser.add_argument('--num_threads',          type=int, default=1,
+                    help='The number of threads is only for the videoDecodePerf sample (sample_mode = 1) - optional (default:1)')
+parser.add_argument('--max_num_decoded_frames',          type=int, default=0,
+                    help='The max number of decoded frames. Useful for partial decoding of a long stream. - optional (default:0, meaning no limit)')
 
 args = parser.parse_args()
 
@@ -75,6 +77,7 @@ filesDir = args.files_directory
 filesDirPath = Path(filesDir)
 sampleMode = args.sample_mode
 numThreads = args.num_threads
+maxNumFrames = args.max_num_decoded_frames
 
 print("\nrunrocDecodeTests V"+__version__+"\n")
 
@@ -113,7 +116,7 @@ if os.path.exists(resultsPath+'/rocDecode_test_results.csv'):
 
 if sampleMode == 0:
     for current_file in iter_files(filesDirPath):
-        os.system(run_rocDecode_app+' -i '+str(current_file)+' -d '+str(gpuDeviceID)+' | tee -a '+resultsPath+'/rocDecode_output.log')
+        os.system(run_rocDecode_app+' -i '+str(current_file)+' -d '+str(gpuDeviceID)+' -f '+str(maxNumFrames)+' | tee -a '+resultsPath+'/rocDecode_output.log')
         print("\n\n")
 
     orig_stdout = sys.stdout
@@ -144,7 +147,7 @@ if sampleMode == 0:
     os.system(runAwk_csv)
 elif sampleMode == 1:
     for current_file in iter_files(filesDirPath):
-        os.system(run_rocDecode_app+' -i '+str(current_file)+' -t '+str(numThreads)+' | tee -a '+resultsPath+'/rocDecode_output.log')
+        os.system(run_rocDecode_app+' -i '+str(current_file)+' -t '+str(numThreads)+' -f '+str(maxNumFrames)+' | tee -a '+resultsPath+'/rocDecode_output.log')
         print("\n\n")
 
     orig_stdout = sys.stdout


### PR DESCRIPTION
- Also changed default thread number from 4 to 1. 
- To discuss: the original default thread number of 4 can cause confusion. If we want to test specific thread number, we should explicitly specify it. We can do so by changing cmake files.
- Also added max number of decoded frames to sample script.