### PR TITLE
Added real decode speed report to set it apart from the current output speed report in sample apps

### DIFF
--- a/src/parser/av1_parser.cpp
+++ b/src/parser/av1_parser.cpp
@@ -180,6 +180,7 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                 ERR(STR("Failed to decode!"));
                 return ret;
             }
+            pic_count_++;
             dpb_buffer_.dec_ref_count[curr_pic_.pic_idx]--;
             memset(&tile_group_data_, 0, sizeof(Av1TileGroupDataInfo));
             if ((ret = DecodeFrameWrapup()) != PARSER_OK) {
@@ -576,7 +577,6 @@ ParserResult Av1VideoParser::DecodeFrameWrapup() {
             return ret;
         }
     }
-    pic_count_++;
     memset(&frame_header_, 0, sizeof(Av1FrameHeader));
     return ret;
 }

--- a/test/testScripts/run_rocDecodeSamples.py
+++ b/test/testScripts/run_rocDecodeSamples.py
@@ -140,10 +140,9 @@ if sampleMode == 0:
                         /\tCrop         : /{next}
                         /\tResize       : /{next}
                         /^$/{next}
-                        /info: Total frame decoded: / {totalFrames=$5; next}
-                        /info: avg decoding time per frame: /{timePerFrame=$7; next}
-                        /info: avg FPS: / { printf("%s, %s, %d, %d, %f, %f\n", filename, codec, bitDepth, totalFrames, timePerFrame, $4) }' rocDecode_videoDecode_results/rocDecode_output.log >> rocDecode_videoDecode_results/rocDecode_test_results.csv'''
-
+                        /info: Total pictures decoded: / {totalFrames=$5; next}
+                        /info: avg decoding time per picture: /{timePerFrame=$7; next}
+                        /info: avg decode FPS: / { printf("%s, %s, %d, %d, %f, %f\n", filename, codec, bitDepth, totalFrames, timePerFrame, $5) }' rocDecode_videoDecode_results/rocDecode_output.log >> rocDecode_videoDecode_results/rocDecode_test_results.csv'''
     os.system(runAwk_csv)
 elif sampleMode == 1:
     for current_file in iter_files(filesDirPath):

--- a/test/testScripts/run_rocDecodeSamples.py
+++ b/test/testScripts/run_rocDecodeSamples.py
@@ -172,9 +172,9 @@ elif sampleMode == 1:
                         /\tCrop         : /{next}
                         /\tResize       : /{next}
                         /^$/{next}
-                        /info: Total frame decoded: / {totalFrames=$5; next}
-                        /info: avg decoding time per frame: /{timePerFrame=$7; next}
-                        /info: avg FPS: / { printf("%s, %d, %s, %d, %d, %f, %f\n", filename, numThreads, codec, bitDepth, totalFrames, timePerFrame, $4) }' rocDecode_videoDecodePerf_results/rocDecode_output.log >> rocDecode_videoDecodePerf_results/rocDecode_test_results.csv'''
+                        /info: Total pictures decoded: / {totalFrames=$5; next}
+                        /info: avg decoding time per picture: /{timePerFrame=$7; next}
+                        /info: avg decode FPS: / { printf("%s, %d, %s, %d, %d, %f, %f\n", filename, numThreads, codec, bitDepth, totalFrames, timePerFrame, $5) }' rocDecode_videoDecodePerf_results/rocDecode_output.log >> rocDecode_videoDecodePerf_results/rocDecode_test_results.csv'''
     sys.stdout = orig_stdout
     os.system(runAwk_csv)
 

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -282,9 +282,10 @@ class RocVideoDecoder {
          * @param size - size of the data buffer in bytes
          * @param pts - presentation timestamp
          * @param flags - video packet flags
+         * @param num_decoded_pics - nummber of pictures decoded in this call
          * @return int - num of frames to display
          */
-        int DecodeFrame(const uint8_t *data, size_t size, int pkt_flags, int64_t pts = 0);
+        int DecodeFrame(const uint8_t *data, size_t size, int pkt_flags, int64_t pts = 0, int *num_decoded_pics = nullptr);
         /**
          * @brief This function returns a decoded frame and timestamp. This should be called in a loop fetching all the available frames
          * 
@@ -475,7 +476,8 @@ class RocVideoDecoder {
         RocdecSeiMessageInfo *curr_sei_message_ptr_ = nullptr;
         RocdecSeiMessageInfo sei_message_display_q_[MAX_FRAME_NUM];
         RocdecVideoFormat *curr_video_format_ptr_ = nullptr;
-        int decoded_frame_cnt_ = 0, decoded_frame_cnt_ret_ = 0;
+        int output_frame_cnt_ = 0, output_frame_cnt_ret_ = 0;
+        int decoded_pic_cnt_ = 0;
         int decode_poc_ = 0, pic_num_in_dec_order_[MAX_FRAME_NUM];
         int num_alloced_frames_ = 0;
         std::ostringstream input_video_info_str_;


### PR DESCRIPTION
 - In sample apps, the current decode speed report is actually output/display speed report. This is all right for AVC and HEVC as decoded frames are normally displayed.
 - Due to AV1's extensive use of alternative reference frames that are not displayed, AV1 decoded frame count and output/displayed frame count can be quite different, making the current speed report not an accurate decode speed measurement.
 - We now added the actual decode speed report, besides the existing speed report, now called output/display FPS. This gives more accurate decode performance report for AV1.
 - Made pic_count_ the decoded frame count, in stead of the count for deocded frame wrap up previously.