### PR TITLE
Package - dependencies updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 Documentation for rocDecode is available at
 [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
+## rocDecode 0.8.0
+
+### Additions
+
+* Clang - Default CXX compiler
+
+### Optimizations
+
+* Setup Script - Build and runtime install options
+
+### Changes
+
+* CTest - Core tests for make test and package test
+* Package - VA driver dependencies updated
+  * VA drivers - only use mesa-amdgpu-va-drivers for both debian and RPM based OS
+  * mesa-amdgpu-va-drivers - brings all it's dependencies
+
+### Fixes
+
+* Sample - Bugfix for videoDecodeBatch
+
+### Tested configurations
+
+* Linux
+  * Ubuntu - `20.04` / `22.04`
+  * RHEL - `8` / `9`
+  * SLES - `15 SP5`
+* ROCm:
+  * rocm-core - `6.2.0.60200-66`
+  * amdgpu-core - `1:6.2.60200-2009582`
+* libva-dev - `2.7.0-2` / `2.14.0-1`
+* mesa-amdgpu-va-drivers - `1:24.2.0.60200-2009582`
+* FFmpeg - `4.2.7` / `4.4.2-0`
+* rocDecode Setup Script - `V2.2.0`
+
 ## rocDecode 0.7.0
 
 ### Additions
@@ -32,7 +67,6 @@ Documentation for rocDecode is available at
   * amdgpu-core - `1:6.2.60200-2009582`
 * libva-dev - `2.7.0-2` / `2.14.0-1`
 * mesa-amdgpu-va-drivers - `1:24.2.0.60200-2009582`
-* mesa-amdgpu-dri-drivers - `24.1.0.60200`
 * FFmpeg - `4.2.7` / `4.4.2-0`
 * rocDecode Setup Script - `V2.2.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,26 +3,31 @@
 Documentation for rocDecode is available at
 [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
-## rocDecode 0.8.0
+## rocDecode 0.8.0 (unreleased)
 
-### Additions
+### Changes
 
 * Clang - Default CXX compiler
+
+### Removals
+
+* CTest - Core tests for make test and package test
+* mesa-amdgpu-dri-drivers - dependencies for RHEL & SLES
 
 ### Optimizations
 
 * Setup Script - Build and runtime install options
 
-### Changes
+### Resolved issues
 
-* CTest - Core tests for make test and package test
 * Package - VA driver dependencies updated
   * VA drivers - only use mesa-amdgpu-va-drivers for both debian and RPM based OS
   * mesa-amdgpu-va-drivers - brings all it's dependencies
-
-### Fixes
-
 * Sample - Bugfix for videoDecodeBatch
+
+### Known issues
+
+### Upcoming changes
 
 ### Tested configurations
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
     set(CMAKE_CXX_COMPILER clang++)
 endif()
 
-set(VERSION "0.7.0")
+set(VERSION "0.8.0")
 set(CMAKE_CXX_STANDARD 17)
 
 # Set Project Version and Language
@@ -194,15 +194,10 @@ if(HIP_FOUND AND Libva_FOUND)
   # Find Ubuntu 22.04 - Add libstdc++-12-dev package deps for Dev Package
   file(READ "/etc/os-release" OS_RELEASE)
   string(REGEX MATCH "22.04" UBUNTU_22_FOUND ${OS_RELEASE})
-  string(REGEX MATCH "SLES" SLES_FOUND ${OS_RELEASE})
-  string(REGEX MATCH "Mariner" MARINER_FOUND ${OS_RELEASE})
 
-  # Set the dependent packages - TBD: mesa-amdgpu-va-drivers should bring libdrm-amdgpu, and parts of mesa-amdgpu-dri-drivers but unavailable on RPM
-  set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, libva2, libdrm-amdgpu1, mesa-amdgpu-va-drivers")
-  set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva, libdrm-amdgpu, mesa-amdgpu-va-drivers, mesa-amdgpu-dri-drivers")
-  if(SLES_FOUND OR MARINER_FOUND)
-    set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, libva2, libdrm-amdgpu, mesa-amdgpu-va-drivers, mesa-amdgpu-dri-drivers")
-  endif()
+  # Set the dependent packages - TBD: To verify mesa-amdgpu-va-drivers should bring in all it's dependencies
+  set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, mesa-amdgpu-va-drivers")
+  set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, mesa-amdgpu-va-drivers")
   # Set the dev dependent packages
   set(rocDecode_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-dev, pkg-config, ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev")
   if(UBUNTU_22_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,15 +196,14 @@ if(HIP_FOUND AND Libva_FOUND)
   string(REGEX MATCH "22.04" UBUNTU_22_FOUND ${OS_RELEASE})
 
   # Set the dependent packages - TBD: To verify mesa-amdgpu-va-drivers should bring in all it's dependencies
-  set(rocDecode_DEBIAN_PACKAGE_LIST  "rocm-hip-runtime, mesa-amdgpu-va-drivers")
-  set(rocDecode_RPM_PACKAGE_LIST     "rocm-hip-runtime, mesa-amdgpu-va-drivers")
+  set(ROCDECODE_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, mesa-amdgpu-va-drivers")
   # Set the dev dependent packages
-  set(rocDecode_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-dev, pkg-config, ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev")
+  set(ROCDECODE_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-dev, pkg-config, ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev")
   if(UBUNTU_22_FOUND)
-    set(rocDecode_DEBIAN_DEV_PACKAGE_LIST "${rocDecode_DEBIAN_DEV_PACKAGE_LIST}, libstdc++-12-dev")
+    set(ROCDECODE_DEBIAN_DEV_PACKAGE_LIST "${ROCDECODE_DEBIAN_DEV_PACKAGE_LIST}, libstdc++-12-dev")
   endif()
   # TBD - RPM packages need Fusion Packages - "ffmpeg, libavcodec-devel, libavformat-devel, libavutil-devel"
-  set(rocDecode_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, libva-devel, pkg-config")
+  set(ROCDECODE_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, libva-devel, pkg-config")
   
   # '%{?dist}' breaks manual builds on debian systems due to empty Provides
   execute_process(
@@ -225,26 +224,26 @@ if(HIP_FOUND AND Libva_FOUND)
   # Debian package
   set(CPACK_DEB_COMPONENT_INSTALL ON)
   set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME "${PROJECT_NAME}")
-  set(CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS "rocm-core, ${rocDecode_DEBIAN_PACKAGE_LIST}")
+  set(CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS "rocm-core, ${ROCDECODE_RUNTIME_PACKAGE_LIST}")
   set(CPACK_DEBIAN_DEV_PACKAGE_NAME "${PROJECT_NAME}-dev")
   set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS 
-  "rocm-core, ${PROJECT_NAME}, ${rocDecode_DEBIAN_DEV_PACKAGE_LIST}")
+  "rocm-core, ${PROJECT_NAME}, ${ROCDECODE_DEBIAN_DEV_PACKAGE_LIST}")
   # Debian package - specific variable for ASAN
   set(CPACK_DEBIAN_ASAN_PACKAGE_NAME "${PROJECT_NAME}-asan" )
-  set(CPACK_DEBIAN_ASAN_PACKAGE_DEPENDS "rocm-core-asan, ${rocDecode_DEBIAN_PACKAGE_LIST}" )
+  set(CPACK_DEBIAN_ASAN_PACKAGE_DEPENDS "rocm-core-asan, ${ROCDECODE_RUNTIME_PACKAGE_LIST}" )
   # Debian package - Test
   set(CPACK_DEBIAN_TEST_PACKAGE_NAME "${PROJECT_NAME}-test" )
   set(CPACK_DEBIAN_TEST_PACKAGE_DEPENDS "rocm-core, ${CPACK_DEBIAN_DEV_PACKAGE_NAME}" )
   # RPM package
   set(CPACK_RPM_COMPONENT_INSTALL ON)
   set(CPACK_RPM_RUNTIME_PACKAGE_NAME "${PROJECT_NAME}")
-  set(CPACK_RPM_RUNTIME_PACKAGE_REQUIRES "rocm-core, ${rocDecode_RPM_PACKAGE_LIST}")
+  set(CPACK_RPM_RUNTIME_PACKAGE_REQUIRES "rocm-core, ${ROCDECODE_RUNTIME_PACKAGE_LIST}")
   set(CPACK_RPM_DEV_PACKAGE_NAME "${PROJECT_NAME}-devel")
-  set(CPACK_RPM_DEV_PACKAGE_REQUIRES "rocm-core, ${PROJECT_NAME}, ${rocDecode_RPM_DEV_PACKAGE_LIST}")
+  set(CPACK_RPM_DEV_PACKAGE_REQUIRES "rocm-core, ${PROJECT_NAME}, ${ROCDECODE_RPM_DEV_PACKAGE_LIST}")
   set(CPACK_RPM_PACKAGE_LICENSE "MIT" )
   # RPM package specific variable for ASAN
   set(CPACK_RPM_ASAN_PACKAGE_NAME "${PROJECT_NAME}-asan" )
-  set(CPACK_RPM_ASAN_PACKAGE_REQUIRES "rocm-core-asan, ${rocDecode_RPM_PACKAGE_LIST}" )
+  set(CPACK_RPM_ASAN_PACKAGE_REQUIRES "rocm-core-asan, ${ROCDECODE_RUNTIME_PACKAGE_LIST}" )
   # RPM package specific variable for Test
   set(CPACK_RPM_TEST_PACKAGE_NAME "${PROJECT_NAME}-test" )
   set(CPACK_RPM_TEST_PACKAGE_REQUIRES "rocm-core, ${CPACK_RPM_DEV_PACKAGE_NAME}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
     set(CMAKE_CXX_COMPILER clang++)
 endif()
 
+# NOTE: Match version with api/rocdecode_version.h
 set(VERSION "0.8.0")
 set(CMAKE_CXX_STANDARD 17)
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,6 @@ access the video decoding features available on your GPU.
 >  ```shell
 >  sudo apt install libstdc++-12-dev
 >  ```
->
-> * On `RHEL`/`SLES` - Additional packages required: `libdrm-amdgpu` and `mesa-amdgpu-dri-drivers`
->
->  ```shell
->  sudo yum install libdrm-amdgpu mesa-amdgpu-dri-drivers
->  ```
 
 >[!NOTE]
 > * All package installs are shown with the `apt` package manager. Use the appropriate package manager for your operating system.
@@ -241,6 +235,5 @@ page.
   * amdgpu-core - `1:6.2.60200-2009582`
 * libva-dev - `2.7.0-2` / `2.14.0-1`
 * mesa-amdgpu-va-drivers - `1:24.2.0.60200-2009582`
-* mesa-amdgpu-dri-drivers - `24.1.0.60200`
 * FFmpeg - `4.2.7` / `4.4.2-0`
 * rocDecode Setup Script - `V2.2.0`

--- a/api/rocdecode_version.h
+++ b/api/rocdecode_version.h
@@ -33,8 +33,9 @@ THE SOFTWARE.
 #ifdef __cplusplus
 extern "C" {
 #endif
+/* NOTE: Match version with CMakeLists.txt */
 #define ROCDECODE_MAJOR_VERSION 0
-#define ROCDECODE_MINOR_VERSION 7
+#define ROCDECODE_MINOR_VERSION 8
 #define ROCDECODE_MICRO_VERSION 0
 
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -26,8 +26,6 @@ Tested configurations
 
 * mesa-amdgpu-va-drivers: 1:24.1.0
 
-* mesa-amdgpu-dri-drivers - `24.1.0.60200`
-
 * FFmpeg: 4.2.7/4.4.2-0
 
 * rocDecode Setup Script: V2.0.0
@@ -99,12 +97,6 @@ Prerequisites
   .. code:: shell
 
     sudo apt install libstdc++-12-dev
-
-  * On ``RHEL`` / ``SLES`` - Additional packages required: ``libdrm-amdgpu`` and ``mesa-amdgpu-dri-drivers``
-
-  .. code:: shell
-
-    sudo apt install libdrm-amdgpu mesa-amdgpu-dri-drivers
 
 
 Prerequisites setup script

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -29,7 +29,7 @@ else:
     import subprocess
 
 __copyright__ = "Copyright (c) 2023 - 2024, AMD ROCm rocDecode"
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 __email__ = "mivisionx.support@amd.com"
 __status__ = "Shipping"
 
@@ -168,14 +168,12 @@ commonPackages = [
 # Debian packages
 coreDebianPackages = [
     'rocm-hip-runtime-dev',
-    'libva2',
     'libva-dev',
 ]
 coreDebianU22Packages = [
     'libstdc++-12-dev'
 ]
 runtimeDebianPackages = [
-    'libdrm-amdgpu1',
     'mesa-amdgpu-va-drivers',
     'vainfo'
 ]
@@ -187,12 +185,8 @@ ffmpegDebianPackages = [
 ]
 
 # RPM Packages
-libvaNameRPM = "libva"
-if "SLES" in os_info_data or "Mariner" in os_info_data:
-    libvaNameRPM = "libva2"
 coreRPMPackages = [
     'rocm-hip-runtime-devel',
-    str(libvaNameRPM),
     'libva-devel'
 ]
 
@@ -200,9 +194,7 @@ libvaUtilsNameRPM = "libva-utils"
 if "Mariner" in os_info_data:
     libvaUtilsNameRPM = "libva2" #TBD - no utils package available 
 runtimeRPMPackages = [
-    'libdrm-amdgpu',
     'mesa-amdgpu-va-drivers',
-    'mesa-amdgpu-dri-drivers',
     str(libvaUtilsNameRPM)
 ]
 

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -107,9 +107,11 @@ linuxCMake = 'cmake'
 linuxSystemInstall_check = ''
 linuxFlag = ''
 sudoValidateOption= '-v'
+osUpdate = ''
 if "centos" in os_info_data or "redhat" in os_info_data:
     linuxSystemInstall = 'yum -y'
     linuxSystemInstall_check = '--nogpgcheck'
+    osUpdate = 'makecache'
     if "VERSION_ID=7" in os_info_data:
         linuxCMake = 'cmake3'
         platfromInfo = platfromInfo+'-redhat-7'
@@ -123,6 +125,7 @@ elif "Ubuntu" in os_info_data:
     linuxSystemInstall = 'apt-get -y'
     linuxSystemInstall_check = '--allow-unauthenticated'
     linuxFlag = '-S'
+    osUpdate = 'update'
     if "VERSION_ID=20" in os_info_data:
         platfromInfo = platfromInfo+'-Ubuntu-20'
     elif "VERSION_ID=22" in os_info_data:
@@ -135,11 +138,13 @@ elif "SLES" in os_info_data:
     linuxSystemInstall = 'zypper -n'
     linuxSystemInstall_check = '--no-gpg-checks'
     platfromInfo = platfromInfo+'-SLES'
+    osUpdate = 'refresh'
 elif "Mariner" in os_info_data:
     linuxSystemInstall = 'tdnf -y'
     linuxSystemInstall_check = '--nogpgcheck'
     platfromInfo = platfromInfo+'-Mariner'
     runtimeInstall = 'OFF'
+    osUpdate = 'makecache'
 else:
     print("\nrocDecode Setup on "+platfromInfo+" is unsupported\n")
     print("\nrocDecode Setup Supported on: Ubuntu 20/22, RedHat 8/9, & SLES 15\n")
@@ -150,7 +155,7 @@ print("\nrocDecode Setup on: "+platfromInfo+"\n")
 print("\nrocDecode Dependencies Installation with rocDecode-setup.py V-"+__version__+"\n")
 
 if userName == 'root':
-    ERROR_CHECK(os.system(linuxSystemInstall+' update'))
+    ERROR_CHECK(os.system(linuxSystemInstall+' '+osUpdate))
     ERROR_CHECK(os.system(linuxSystemInstall+' install sudo'))
 
 # source install - common package dependencies
@@ -199,7 +204,7 @@ runtimeRPMPackages = [
 ]
 
 # update
-ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +' '+linuxSystemInstall_check+' update'))
+ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +' '+linuxSystemInstall_check+' '+osUpdate))
 
 # common packages
 ERROR_CHECK(os.system('sudo '+sudoValidateOption))


### PR DESCRIPTION
Package Dependencies updates
* Use mesa-amdgpu-va-drivers - for both Debian and RPM based OS
* mesa-amdgpu-va-drivers should bring in it's dependencies 

Dri drivers deprecated by the driver team