### PR TITLE
Fix libva requirements for rocdecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ Documentation for rocDecode is available at
 ### Resolved issues
 
 * Package - VA driver dependencies updated
-  * VA drivers - only use mesa-amdgpu-va-drivers for both debian and RPM based OS
-  * mesa-amdgpu-va-drivers - brings all it's dependencies
+  * VA drivers - libva-amdgpu packages are now used to avoid API related issues
 * Sample - Bugfix for videoDecodeBatch
 
 ### Known issues

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,15 +196,20 @@ if(HIP_FOUND AND Libva_FOUND)
   file(READ "/etc/os-release" OS_RELEASE)
   string(REGEX MATCH "22.04" UBUNTU_22_FOUND ${OS_RELEASE})
 
-  # Set the dependent packages - TBD: To verify mesa-amdgpu-va-drivers should bring in all it's dependencies
-  set(ROCDECODE_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, mesa-amdgpu-va-drivers")
+  # Set the dependent packages
+  # libva 2.16 (API 1.16) is needed to use mesa-amdgpu-va-drivers, libva-amdgpu
+  # (AMD build of libva 2.16) should be used if distro's libva is too old
+  # Libva is 2.12 on Ubuntu 22.04 and 24.04, so we can always use libva-amdgpu
+  set(ROCDECODE_DEBIAN_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, libva2-amdgpu, libva-amdgpu-drm2, libva-amdgpu-wayland2, libva-amdgpu-x11-2, mesa-amdgpu-va-drivers")
+  # Unfortunately RPM has a mix of versions; RHEL has "libva", SLE has "libva2"
+  set(ROCDECODE_RPM_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, (libva >= 2.16.0 or libva2 >= 2.16.0 or libva-amdgpu), mesa-amdgpu-va-drivers")
   # Set the dev dependent packages
-  set(ROCDECODE_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-dev, pkg-config, ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev")
+  set(ROCDECODE_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-amdgpu-dev, pkg-config, ffmpeg, libavcodec-dev, libavformat-dev, libavutil-dev")
   if(UBUNTU_22_FOUND)
     set(ROCDECODE_DEBIAN_DEV_PACKAGE_LIST "${ROCDECODE_DEBIAN_DEV_PACKAGE_LIST}, libstdc++-12-dev")
   endif()
   # TBD - RPM packages need Fusion Packages - "ffmpeg, libavcodec-devel, libavformat-devel, libavutil-devel"
-  set(ROCDECODE_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, libva-devel, pkg-config")
+  set(ROCDECODE_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, libva-amdgpu-devel, pkg-config")
   
   # '%{?dist}' breaks manual builds on debian systems due to empty Provides
   execute_process(
@@ -225,26 +230,26 @@ if(HIP_FOUND AND Libva_FOUND)
   # Debian package
   set(CPACK_DEB_COMPONENT_INSTALL ON)
   set(CPACK_DEBIAN_RUNTIME_PACKAGE_NAME "${PROJECT_NAME}")
-  set(CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS "rocm-core, ${ROCDECODE_RUNTIME_PACKAGE_LIST}")
+  set(CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS "rocm-core, ${ROCDECODE_DEBIAN_RUNTIME_PACKAGE_LIST}")
   set(CPACK_DEBIAN_DEV_PACKAGE_NAME "${PROJECT_NAME}-dev")
   set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS 
   "rocm-core, ${PROJECT_NAME}, ${ROCDECODE_DEBIAN_DEV_PACKAGE_LIST}")
   # Debian package - specific variable for ASAN
   set(CPACK_DEBIAN_ASAN_PACKAGE_NAME "${PROJECT_NAME}-asan" )
-  set(CPACK_DEBIAN_ASAN_PACKAGE_DEPENDS "rocm-core-asan, ${ROCDECODE_RUNTIME_PACKAGE_LIST}" )
+  set(CPACK_DEBIAN_ASAN_PACKAGE_DEPENDS "rocm-core-asan, ${ROCDECODE_DEBIAN_RUNTIME_PACKAGE_LIST}" )
   # Debian package - Test
   set(CPACK_DEBIAN_TEST_PACKAGE_NAME "${PROJECT_NAME}-test" )
   set(CPACK_DEBIAN_TEST_PACKAGE_DEPENDS "rocm-core, ${CPACK_DEBIAN_DEV_PACKAGE_NAME}" )
   # RPM package
   set(CPACK_RPM_COMPONENT_INSTALL ON)
   set(CPACK_RPM_RUNTIME_PACKAGE_NAME "${PROJECT_NAME}")
-  set(CPACK_RPM_RUNTIME_PACKAGE_REQUIRES "rocm-core, ${ROCDECODE_RUNTIME_PACKAGE_LIST}")
+  set(CPACK_RPM_RUNTIME_PACKAGE_REQUIRES "rocm-core, ${ROCDECODE_RPM_RUNTIME_PACKAGE_LIST}")
   set(CPACK_RPM_DEV_PACKAGE_NAME "${PROJECT_NAME}-devel")
   set(CPACK_RPM_DEV_PACKAGE_REQUIRES "rocm-core, ${PROJECT_NAME}, ${ROCDECODE_RPM_DEV_PACKAGE_LIST}")
   set(CPACK_RPM_PACKAGE_LICENSE "MIT" )
   # RPM package specific variable for ASAN
   set(CPACK_RPM_ASAN_PACKAGE_NAME "${PROJECT_NAME}-asan" )
-  set(CPACK_RPM_ASAN_PACKAGE_REQUIRES "rocm-core-asan, ${ROCDECODE_RUNTIME_PACKAGE_LIST}" )
+  set(CPACK_RPM_ASAN_PACKAGE_REQUIRES "rocm-core-asan, ${ROCDECODE_RPM_RUNTIME_PACKAGE_LIST}" )
   # RPM package specific variable for Test
   set(CPACK_RPM_TEST_PACKAGE_NAME "${PROJECT_NAME}-test" )
   set(CPACK_RPM_TEST_PACKAGE_REQUIRES "rocm-core, ${CPACK_RPM_DEV_PACKAGE_NAME}" )

--- a/README.md
+++ b/README.md
@@ -29,17 +29,20 @@ access the video decoding features available on your GPU.
 > [!IMPORTANT]
 > `sudo amdgpu-install --usecase=rocm`
 
-* [Video Acceleration API](https://en.wikipedia.org/wiki/Video_Acceleration_API) Version `1.5.0` or later - `Libva` is an implementation for VA-API
+* [Video Acceleration API](https://en.wikipedia.org/wiki/Video_Acceleration_API) - `Libva` is an implementation for VA-API
   ```shell
-  sudo apt install libva-dev
+  sudo apt install libva-amdgpu-dev
   ```
 > [!NOTE]
-> RPM Packages for `RHEL`/`SLES` - `libva-devel`
+> RPM Packages for `RHEL`/`SLES` - `libva-amdgpu-devel`
+> libva-amdgpu is strongly recommended over system libva as it is used for building mesa-amdgpu-va-driver
 
 * AMD VA Drivers
   ```shell
-  sudo apt install mesa-amdgpu-va-drivers
+  sudo apt install libva2-amdgpu libva-amdgpu-drm2 libva-amdgpu-wayland2 libva-amdgpu-x11-2 mesa-amdgpu-va-drivers
   ```
+> [!NOTE]
+> RPM Packages for `RHEL`/`SLES` - `libva-amdgpu mesa-amdgpu-va-drivers`
 
 * CMake Version `3.5` or later
 

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -172,13 +172,17 @@ commonPackages = [
 
 # Debian packages
 coreDebianPackages = [
+    'libva-amdgpu-dev',
     'rocm-hip-runtime-dev',
-    'libva-dev',
 ]
 coreDebianU22Packages = [
     'libstdc++-12-dev'
 ]
 runtimeDebianPackages = [
+    'libva2-amdgpu',
+    'libva-amdgpu-drm2',
+    'libva-amdgpu-wayland2',
+    'libva-amdgpu-x11-2',
     'mesa-amdgpu-va-drivers',
     'vainfo'
 ]
@@ -191,16 +195,13 @@ ffmpegDebianPackages = [
 
 # RPM Packages
 coreRPMPackages = [
+    'libva-amdgpu-devel'
     'rocm-hip-runtime-devel',
-    'libva-devel'
 ]
-
-libvaUtilsNameRPM = "libva-utils"
-if "Mariner" in os_info_data:
-    libvaUtilsNameRPM = "libva2" #TBD - no utils package available 
 runtimeRPMPackages = [
+    'libva-amdgpu',
+    'libva-utils',
     'mesa-amdgpu-va-drivers',
-    str(libvaUtilsNameRPM)
 ]
 
 # update


### PR DESCRIPTION
mesa-amdgpu-va-drivers is built with libva 2.16 (VA-API 1.16), so it provides the entry point "__vaDriverInit_1_16". For rocdecode to use mesa, it also needs to make sure it has a high enough requirement on libva to be compatible with this function.

Strictly speaking, it doesn't matter what libva is used as long as it's 2.16 or newer, since libva is backwards compatible. An OR conditions is used to favour distro packages when possible to avoid causing issues with existing libraries built against the distro version.

For libva dev packages, we can just use libva-amdgpu-dev/el directly.