### PR TITLE
Allow overriding CMAKE_CXX_COMPILER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ message("-- ${BoldBlue}rocDecode Install Path -- ${CMAKE_INSTALL_PREFIX}${Colour
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} ${ROCM_PATH}/hip)
-set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++)
+set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++ CACHE STRING "ROCm Compiler path")
 
 # rocDecode Build Type
 if(NOT CMAKE_BUILD_TYPE)

--- a/samples/videoDecode/CMakeLists.txt
+++ b/samples/videoDecode/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
-set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++)
+set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++ CACHE STRING "ROCm Compiler path")
 
 # rocDecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/samples/videoDecodeBatch/CMakeLists.txt
+++ b/samples/videoDecodeBatch/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
-set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++)
+set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++ CACHE STRING "ROCm Compiler path")
 
 # rocDecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/samples/videoDecodeMem/CMakeLists.txt
+++ b/samples/videoDecodeMem/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
-set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++)
+set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++ CACHE STRING "ROCm Compiler path")
 
 # rocDecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/samples/videoDecodeMultiFiles/CMakeLists.txt
+++ b/samples/videoDecodeMultiFiles/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
-set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++)
+set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++ CACHE STRING "ROCm Compiler path")
 
 # rocDecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/samples/videoDecodePerf/CMakeLists.txt
+++ b/samples/videoDecodePerf/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
-set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++)
+set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++ CACHE STRING "ROCm Compiler path")
 
 # rocDecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/samples/videoDecodeRGB/CMakeLists.txt
+++ b/samples/videoDecodeRGB/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
-set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++)
+set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++ CACHE STRING "ROCm Compiler path")
 
 # rocDecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/samples/videoToSequence/CMakeLists.txt
+++ b/samples/videoToSequence/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/hip ${ROCM_PATH})
-set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++)
+set(CMAKE_CXX_COMPILER ${ROCM_PATH}/lib/llvm/bin/clang++ CACHE STRING "ROCm Compiler path")
 
 # rocDecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")


### PR DESCRIPTION
Using set as-is doesn't allow the user to set their own rocm path. This is useful for community packagers or debugging.