### PR TITLE
Fix exit code for rocDecode-setup.py

### DIFF
--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -34,11 +34,11 @@ __email__ = "mivisionx.support@amd.com"
 __status__ = "Shipping"
 
 # error check calls
-def ERROR_CHECK(call):
-    status = call
-    if(status != 0):
-        print('ERROR_CHECK failed with status:'+str(status))
+def ERROR_CHECK(waitval):
+    if(waitval != 0): # return code and signal flags
+        print('ERROR_CHECK failed with status:'+str(waitval))
         traceback.print_stack()
+        status = ((waitval >> 8) | waitval) & 255 # combine exit code and wait flags into single non-zero byte
         exit(status)
 
 # Arguments


### PR DESCRIPTION
The code is full of ERROR_CHECK(os.system("some shell commands")).

Unfortunately the return value from os.system is a 16 bit value with the return code in the upper 8 bits and a number of flags related to the traps in the lower 8 bits. The existing code passes this 16 bit value to the os.exit call, which just uses the bottom 8 bits. Unless the child process is killed by a signal these 8 bits will be zero, which is taken as "success", rather than passing on the exit status of the child process.

So even something as simple as 
    ERROR_CHECK(os.system("false"))
will report a status of 256 in the print statement but will call sys.exit() with a value of 0 in the lower 8 bits.

This change folds the top and bottom halves of the 16 bit value into an 8 bit value. This will be non-zero, so a shell script running rocDecode-setup.py will know something has failed an ERROR_CHECK, rather than the current situation where it thinks things are correct.