### PR TITLE
Bug fix - batch sample

### DIFF
--- a/samples/videoDecodeBatch/videodecodebatch.cpp
+++ b/samples/videoDecodeBatch/videodecodebatch.cpp
@@ -435,6 +435,7 @@ int main(int argc, char **argv) {
             }
             if (!v_dec_info[thread_idx]->viddec->CodecSupported(v_dec_info[thread_idx]->dec_device_id, v_dec_info[thread_idx]->rocdec_codec_id, v_dec_info[thread_idx]->bit_depth)) {
                 std::cerr << "Codec not supported on GPU, skipping this file!" << std::endl;
+                v_dec_info[thread_idx]->decoding_complete = true;
                 continue;
             }
             thread_pool.ExecuteJob(std::bind(DecProc, v_dec_info[thread_idx]->viddec.get(), v_demuxer[j].get(), &v_frame[j], &v_fps[j], std::ref(v_dec_info[thread_idx]->decoding_complete), b_dump_output_frames, output_file_names[j], mem_type));


### PR DESCRIPTION
Bug fix for MI200 system (issue reported by QA) which does not support AV1. The thread which has the AV1 stream needs to be marked as complete to proceed.

```
master@hy-7c0209-rcqe-07:~/lakshmi/rocDecode/build$ make test
Running tests...
Test project /home/master/lakshmi/rocDecode/build
    Start 1: video_decode-H265
1/7 Test #1: video_decode-H265 ................   Passed    6.33 sec
    Start 2: video_decodeMem-H265
2/7 Test #2: video_decodeMem-H265 .............   Passed    6.29 sec
    Start 3: video_decodePerf-H265
3/7 Test #3: video_decodePerf-H265 ............   Passed    6.78 sec
    Start 4: video_decodeRGB-H265
4/7 Test #4: video_decodeRGB-H265 .............   Passed   84.03 sec
    Start 5: video_decode-H264
5/7 Test #5: video_decode-H264 ................   Passed    5.97 sec
    Start 6: video_decodeBatch
6/7 Test #6: video_decodeBatch ................   Passed    7.94 sec
    Start 7: video_decode-AV1
7/7 Test #7: video_decode-AV1 .................   Passed    4.69 sec

100% tests passed, 0 tests failed out of 7

Total Test time (real) = 122.04 sec
master@hy-7c0209-rcqe-07:~/lakshmi/rocDecode/build$

```