### PR TITLE
Use a pointer for the horizontal_pitch parameter in the rocDecGetVideoFrame API

### DIFF
--- a/api/amd_detail/rocdecode_api_trace.h
+++ b/api/amd_detail/rocdecode_api_trace.h
@@ -59,7 +59,7 @@ typedef rocDecStatus (ROCDECAPI *PfnRocDecGetDecoderCaps)(RocdecDecodeCaps *deco
 typedef rocDecStatus (ROCDECAPI *PfnRocDecDecodeFrame)(rocDecDecoderHandle decoder_handle, RocdecPicParams *pic_params);
 typedef rocDecStatus (ROCDECAPI *PfnRocDecGetDecodeStatus)(rocDecDecoderHandle decoder_handle, int pic_idx, RocdecDecodeStatus *decode_status);
 typedef rocDecStatus (ROCDECAPI *PfnRocDecReconfigureDecoder)(rocDecDecoderHandle decoder_handle, RocdecReconfigureDecoderInfo *reconfig_params);
-typedef rocDecStatus (ROCDECAPI *PfnRocDecGetVideoFrame)(rocDecDecoderHandle decoder_handle, int pic_idx, void *dev_mem_ptr[3], uint32_t (&horizontal_pitch)[3], RocdecProcParams *vid_postproc_params);
+typedef rocDecStatus (ROCDECAPI *PfnRocDecGetVideoFrame)(rocDecDecoderHandle decoder_handle, int pic_idx, void *dev_mem_ptr[3], uint32_t *horizontal_pitch, RocdecProcParams *vid_postproc_params);
 typedef const char* (ROCDECAPI *PfnRocDecGetErrorName)(rocDecStatus rocdec_status);
 typedef rocDecStatus (ROCDECAPI *PfnRocDecCreateBitstreamReader)(RocdecBitstreamReader *bs_reader_handle, const char *input_file_path);
 typedef rocDecStatus (ROCDECAPI *PfnRocDecGetBitstreamCodecType)(RocdecBitstreamReader bs_reader_handle, rocDecVideoCodec *codec_type);

--- a/api/rocdecode.h
+++ b/api/rocdecode.h
@@ -1735,9 +1735,10 @@ extern rocDecStatus ROCDECAPI rocDecReconfigureDecoder(rocDecDecoderHandle decod
 //! \ingroup group_amd_rocdecode
 //! Post-process and map video frame corresponding to pic_idx for use in HIP. Returns HIP device pointer and associated
 //! pitch(horizontal stride) of the video frame. Returns device memory pointers and pitch for each plane (Y, U and V) seperately
+//! horizontal_pitch is a pointer to an unsigned 32-bit integer array of size 3.
 /************************************************************************************************************************/
 extern rocDecStatus ROCDECAPI rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx,
-                                                    void *dev_mem_ptr[3], uint32_t (&horizontal_pitch)[3],
+                                                    void *dev_mem_ptr[3], uint32_t *horizontal_pitch,
                                                     RocdecProcParams *vid_postproc_params);
 
 /*****************************************************************************************************/

--- a/src/amd_detail/rocdecode_api_dispatch_interface.cpp
+++ b/src/amd_detail/rocdecode_api_dispatch_interface.cpp
@@ -52,7 +52,7 @@ rocDecStatus ROCDECAPI rocDecGetDecodeStatus(rocDecDecoderHandle decoder_handle,
 rocDecStatus ROCDECAPI rocDecReconfigureDecoder(rocDecDecoderHandle decoder_handle, RocdecReconfigureDecoderInfo *reconfig_params) {
     return rocdecode::GetRocDecodeDispatchTable()->pfn_rocdec_reconfigure_decoder(decoder_handle, reconfig_params);
 }
-rocDecStatus ROCDECAPI rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx, void *dev_mem_ptr[3], uint32_t (&horizontal_pitch)[3], RocdecProcParams *vid_postproc_params) {
+rocDecStatus ROCDECAPI rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx, void *dev_mem_ptr[3], uint32_t *horizontal_pitch, RocdecProcParams *vid_postproc_params) {
     return rocdecode::GetRocDecodeDispatchTable()->pfn_rocdec_get_video_frame(decoder_handle, pic_idx, dev_mem_ptr, horizontal_pitch, vid_postproc_params);
 }
 const char *ROCDECAPI rocDecGetErrorName(rocDecStatus rocdec_status) {

--- a/src/amd_detail/rocdecode_api_trace.cpp
+++ b/src/amd_detail/rocdecode_api_trace.cpp
@@ -43,7 +43,7 @@ rocDecStatus ROCDECAPI rocDecGetDecoderCaps(RocdecDecodeCaps *decode_caps);
 rocDecStatus ROCDECAPI rocDecDecodeFrame(rocDecDecoderHandle decoder_handle, RocdecPicParams *pic_params);
 rocDecStatus ROCDECAPI rocDecGetDecodeStatus(rocDecDecoderHandle decoder_handle, int pic_idx, RocdecDecodeStatus *decode_status);
 rocDecStatus ROCDECAPI rocDecReconfigureDecoder(rocDecDecoderHandle decoder_handle, RocdecReconfigureDecoderInfo *reconfig_params);
-rocDecStatus ROCDECAPI rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx, void *dev_mem_ptr[3], uint32_t (&horizontal_pitch)[3], RocdecProcParams *vid_postproc_params);
+rocDecStatus ROCDECAPI rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx, void *dev_mem_ptr[3], uint32_t *horizontal_pitch, RocdecProcParams *vid_postproc_params);
 const char *ROCDECAPI rocDecGetErrorName(rocDecStatus rocdec_status);
 rocDecStatus ROCDECAPI rocDecCreateBitstreamReader(RocdecBitstreamReader *bs_reader_handle, const char *input_file_path);
 rocDecStatus ROCDECAPI rocDecGetBitstreamCodecType(RocdecBitstreamReader bs_reader_handle, rocDecVideoCodec *codec_type);

--- a/src/rocdecode/rocdecode_api.cpp
+++ b/src/rocdecode/rocdecode_api.cpp
@@ -176,7 +176,7 @@ rocDecReconfigureDecoder(rocDecDecoderHandle decoder_handle, RocdecReconfigureDe
 /************************************************************************************************************************/
 rocDecStatus ROCDECAPI 
 rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx,
-                    void *dev_mem_ptr[3], uint32_t (&horizontal_pitch)[3], RocdecProcParams *vid_postproc_params) {
+                    void *dev_mem_ptr[3], uint32_t *horizontal_pitch, RocdecProcParams *vid_postproc_params) {
     if (decoder_handle == nullptr || dev_mem_ptr == nullptr || horizontal_pitch == nullptr || vid_postproc_params == nullptr) {
         return ROCDEC_INVALID_PARAMETER;
     }


### PR DESCRIPTION
This PR ensures that the `rocDecGetVideoFrame` API is compatible with the C compiler.