### PR TITLE
VP9: Fixed issues with filter parameters.

### DIFF
--- a/src/parser/vp9_parser.cpp
+++ b/src/parser/vp9_parser.cpp
@@ -266,7 +266,7 @@ ParserResult Vp9VideoParser::SendPicForDecode() {
     p_pic_param->pic_fields.bits.error_resilient_mode = p_uncomp_header->error_resilient_mode;
     p_pic_param->pic_fields.bits.intra_only = p_uncomp_header->intra_only;
     p_pic_param->pic_fields.bits.allow_high_precision_mv = p_uncomp_header->allow_high_precision_mv;
-    p_pic_param->pic_fields.bits.mcomp_filter_type = p_uncomp_header->interpolation_filter ^ (p_uncomp_header->interpolation_filter <= 1);
+    p_pic_param->pic_fields.bits.mcomp_filter_type = p_uncomp_header->interpolation_filter;
     p_pic_param->pic_fields.bits.frame_parallel_decoding_mode = p_uncomp_header->frame_parallel_decoding_mode;
     p_pic_param->pic_fields.bits.reset_frame_context = p_uncomp_header->reset_frame_context;
     p_pic_param->pic_fields.bits.refresh_frame_context = p_uncomp_header->refresh_frame_context;
@@ -995,7 +995,8 @@ void Vp9VideoParser::LoopFilterFrameInit(Vp9UncompressedHeader *p_uncomp_header)
         }
         if (p_uncomp_header->loop_filter_params.loop_filter_delta_update == 0) {
             memset(lvl_lookup_[seg_id], lvl_seg, VP9_MAX_REF_FRAMES * MAX_MODE_LF_DELTAS * sizeof(uint8_t));
-        } else {
+        }
+        if (p_uncomp_header->loop_filter_params.loop_filter_delta_enabled) {
             uint8_t intra_lvl = lvl_seg + (p_uncomp_header->loop_filter_params.loop_filter_ref_deltas[kVp9IntraFrame] << n_shift);
             lvl_lookup_[seg_id][kVp9IntraFrame][0] = std::clamp(static_cast<int>(intra_lvl), 0, VP9_MAX_LOOP_FILTER);
             for (int ref = kVp9LastFrame; ref < VP9_MAX_REF_FRAMES; ref++) {


### PR DESCRIPTION
 - Fixed a condition check in loop filter frame init process.
 - Removed the redundant conversion in interpolation filter assignment in VAAPI. The conversion has been done already when we parse the interpolation filter syntax.