### PR TITLE
Optimize finding the compute partition mode

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.h
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.h
@@ -153,7 +153,7 @@ private:
      * retrieve the render node index for a given GPU UUID.
      */
     std::unordered_map<std::string, int> gpu_uuids_to_render_nodes_map_;
-
+    std::unordered_map<std::string, ComputePartition> gpu_uuids_to_compute_partition_map_;
     VaContext();
     VaContext(const VaContext&) = delete;
     VaContext& operator = (const VaContext) = delete;
@@ -162,7 +162,6 @@ private:
     rocDecStatus InitHIP(int device_id, hipDeviceProp_t& hip_dev_prop);
     rocDecStatus InitVAAPI(int va_ctx_idx, std::string drm_node);
     void GetVisibleDevices(std::vector<int>& visible_devices_vetor);
-    void GetCurrentComputePartition(std::vector<ComputePartition> &current_compute_partitions);
-    void GetDrmNodeOffset(std::string device_name, uint8_t device_id, std::vector<int>& visible_devices, std::vector<ComputePartition> &current_compute_partitions, int &offset);
+    void GetDrmNodeOffset(std::string device_name, uint8_t device_id, std::vector<int>& visible_devices, ComputePartition current_compute_partition, int &offset);
     void GetGpuUuids();
 };


### PR DESCRIPTION
This PR optimizes how we determine the compute partition mode. Previously, we searched the `/sys/devices/` directory recursively to locate the `current_compute_partition`. However, we can obtain the `current_compute_partition` from the same sysfs path used to read the GPU's `unique_id`. This PR combines the searches for both the GPU `unique_id` and the `current_compute_partition`, eliminating the overhead of searching in two separate sysfs paths.