### PR TITLE
Setup - Install ffmpeg-devel on RHEL 9

### DIFF
--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -263,7 +263,7 @@ if developerInstall == 'ON':
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall+' '+linuxSystemInstall_check +
                 ' install https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-$(rpm -E %rhel).noarch.rpm'))
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall+' '+linuxSystemInstall_check +
-                ' install ffmpeg ffmpeg-free-devel'))
+                ' install ffmpeg ffmpeg-devel'))
         elif "SLES" in platfromInfo:
             # FFMPEG-4 packages
             ERROR_CHECK(os.system(


### PR DESCRIPTION
Fixes an FFMPEG package conflict when running the setup script on RHEL 9. Tested to work on RHEL 9.5.

```
Error:
Problem: package libavcodec-free-devel-5.1.4-3.el9.x86_64 from epel requires libavcodec-free(x86-64) = 5.1.4-3.el9, but none of the providers can be installed
  - package ffmpeg-libs-5.1.6-2.el9.x86_64 from rpmfusion-free-updates conflicts with libavcodec-free provided by libavcodec-free-5.1.4-3.el9.x86_64 from epel
  - package ffmpeg-free-devel-5.1.4-3.el9.x86_64 from epel requires libavcodec-free-devel = 5.1.4-3.el9, but none of the providers can be installed
  - package ffmpeg-5.1.6-2.el9.x86_64 from rpmfusion-free-updates requires ffmpeg-libs(x86-64) = 5.1.6-2.el9, but none of the providers can be installed
  - conflicting requests
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
ERROR_CHECK failed with status:256
  File "/home/rocm/rocm-examples/build/rocDecode/rocDecode-setup.py", line 265, in <module>
    ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall+' '+linuxSystemInstall_check +
  File "/home/rocm/rocm-examples/build/rocDecode/rocDecode-setup.py", line 40, in ERROR_CHECK
    traceback.print_stack()
```