### PR TITLE
rename some macros so it doesn't clash with others

### DIFF
--- a/samples/videoDecode/videodecode.cpp
+++ b/samples/videoDecode/videodecode.cpp
@@ -47,7 +47,7 @@ void ShowHelpAndExit(const char *option = NULL) {
     << "-i Input File Path - required" << std::endl
     << "-o Output File Path - dumps output if requested; optional" << std::endl
     << "-d GPU device ID (0 for the first device, 1 for the second, etc.); optional; default: 0" << std::endl
-    << "-backend backend (0 for GPU, 1 CPU-FFMpeg, 2 CPU-FFMpeg No threading); optional; default: 0" << std::endl
+    << "-backend backend (0 for GPU, 1 CPU-FFMpeg); optional; default: 0" << std::endl
     << "-f Number of decoded frames - specify the number of pictures to be decoded; optional" << std::endl
     << "-z force_zero_latency (force_zero_latency, Decoded frames will be flushed out for display immediately); optional;" << std::endl
     << "-disp_delay -specify the number of frames to be delayed for display; optional; default: 1" << std::endl
@@ -262,10 +262,7 @@ int main(int argc, char **argv) {
             std::cout << "info: RocDecode is using CPU backend!" << std::endl;
             bool use_threading = false;
             if (mem_type == OUT_SURFACE_MEM_DEV_INTERNAL) mem_type = OUT_SURFACE_MEM_DEV_COPIED;    // mem_type internal is not supported in this mode
-            if (backend == 1) {
-                viddec = new FFMpegVideoDecoder(device_id, mem_type, rocdec_codec_id, b_force_zero_latency, p_crop_rect, b_extract_sei_messages, disp_delay);
-            } else
-                viddec = new FFMpegVideoDecoder(device_id, mem_type, rocdec_codec_id, b_force_zero_latency, p_crop_rect, b_extract_sei_messages, disp_delay, true);
+            viddec = new FFMpegVideoDecoder(device_id, mem_type, rocdec_codec_id, b_force_zero_latency, p_crop_rect, b_extract_sei_messages, disp_delay, true);
         }
 
         if(!viddec->CodecSupported(device_id, rocdec_codec_id, bit_depth)) {

--- a/samples/videoDecodeBatch/videodecodebatch.cpp
+++ b/samples/videoDecodeBatch/videodecodebatch.cpp
@@ -274,13 +274,13 @@ int main(int argc, char **argv) {
             return -1;
         }
         if (num_devices < 1) {
-            ERR("ERROR: didn't find any GPU!");
+            ROCDEC_ERR("ERROR: didn't find any GPU!");
             return -1;
         }
 
         hip_status = hipGetDeviceProperties(&hip_dev_prop, device_id);
         if (hip_status != hipSuccess) {
-            ERR("ERROR: hipGetDeviceProperties for device (" +TOSTR(device_id) + " ) failed! (" + hipGetErrorName(hip_status) + ")" );
+            ROCDEC_ERR("ERROR: hipGetDeviceProperties for device (" +TOSTR(device_id) + " ) failed! (" + hipGetErrorName(hip_status) + ")" );
             return -1;
         }
 
@@ -363,7 +363,7 @@ int main(int argc, char **argv) {
                     std::unique_ptr<RocVideoDecoder> dec_8bit_vp9(new RocVideoDecoder(v_dec_info[i]->dec_device_id, mem_type, v_dec_info[i]->rocdec_codec_id, b_force_zero_latency, p_crop_rect, b_extract_sei_messages, disp_delay));
                     v_dec_info[i]->viddec = std::move(dec_8bit_vp9);
                 } else {
-                    ERR("ERROR: codec type is not supported!");
+                    ROCDEC_ERR("ERROR: codec type is not supported!");
                     return -1;
                 }
             } else { //bit depth = 10bit
@@ -377,7 +377,7 @@ int main(int argc, char **argv) {
                     std::unique_ptr<RocVideoDecoder> dec_10bit_vp9(new RocVideoDecoder(v_dec_info[i]->dec_device_id, mem_type, v_dec_info[i]->rocdec_codec_id, b_force_zero_latency, p_crop_rect, b_extract_sei_messages, disp_delay));
                     v_dec_info[i]->viddec = std::move(dec_10bit_vp9);
                 } else {
-                    ERR("ERROR: codec type is not supported!");
+                    ROCDEC_ERR("ERROR: codec type is not supported!");
                     return -1;
                 }
             }
@@ -424,7 +424,7 @@ int main(int argc, char **argv) {
                             } else if (codec_id == rocDecVideoCodec_VP9) {
                                 v_dec_info[thread_idx]->viddec.swap(dec_8bit_vp9);
                             } else {
-                                ERR("ERROR: codec type is not supported!");
+                                ROCDEC_ERR("ERROR: codec type is not supported!");
                                 return -1;
                             }
                         }
@@ -448,7 +448,7 @@ int main(int argc, char **argv) {
                             } else if (codec_id == rocDecVideoCodec_VP9) {
                                 v_dec_info[thread_idx]->viddec.swap(dec_10bit_vp9);
                             } else {
-                                ERR("ERROR: codec type is not supported!");
+                                ROCDEC_ERR("ERROR: codec type is not supported!");
                                 return -1;
                             }
                         }

--- a/samples/videoDecodePerf/videodecodeperf.cpp
+++ b/samples/videoDecodePerf/videodecodeperf.cpp
@@ -178,13 +178,13 @@ int main(int argc, char **argv) {
         }
 
         if (num_devices < 1) {
-            ERR("ERROR: didn't find any GPU!");
+            ROCDEC_ERR("ERROR: didn't find any GPU!");
             return -1;
         }
 
         hip_status = hipGetDeviceProperties(&hip_dev_prop, device_id);
         if (hip_status != hipSuccess) {
-            ERR("ERROR: hipGetDeviceProperties for device (" +TOSTR(device_id) + " ) failed! (" + hipGetErrorName(hip_status) + ")" );
+            ROCDEC_ERR("ERROR: hipGetDeviceProperties for device (" +TOSTR(device_id) + " ) failed! (" + hipGetErrorName(hip_status) + ")" );
             return -1;
         }
 

--- a/samples/videoToSequence/videotosequence.cpp
+++ b/samples/videoToSequence/videotosequence.cpp
@@ -391,12 +391,12 @@ int main(int argc, char **argv) {
             return -1;
         }
         if (num_devices < 1) {
-            ERR("ERROR: didn't find any GPU!");
+            ROCDEC_ERR("ERROR: didn't find any GPU!");
             return -1;
         }
 
         if (hipSuccess != hipGetDeviceProperties(&hip_dev_prop, device_id)) {
-            ERR("ERROR: hipGetDeviceProperties for device (" +TOSTR(device_id) + " ) failed! (" + hipGetErrorName(hip_status) + ")" );
+            ROCDEC_ERR("ERROR: hipGetDeviceProperties for device (" +TOSTR(device_id) + " ) failed! (" + hipGetErrorName(hip_status) + ")" );
             return -1;
         }
 

--- a/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
+++ b/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
@@ -92,7 +92,7 @@ FFMpegVideoDecoder::FFMpegVideoDecoder(int device_id, OutputSurfaceMemoryType ou
               RocVideoDecoder(device_id, out_mem_type, codec, force_zero_latency, p_crop_rect, extract_user_sei_Message, disp_delay, max_width, max_height, clk_rate), no_multithreading_(no_multithreading) {
 
     if ((out_mem_type_ == OUT_SURFACE_MEM_DEV_INTERNAL) || (out_mem_type_ == OUT_SURFACE_MEM_NOT_MAPPED)) {
-        THROW("Output Memory Type is not supported");
+        ROCDEC_THROW("Output Memory Type is not supported", ROCDEC_INVALID_PARAMETER);
     }
     if (rocdec_parser_) {
         rocDecDestroyVideoParser(rocdec_parser_);       // need to do this here since it was already created in the base class
@@ -113,7 +113,7 @@ FFMpegVideoDecoder::FFMpegVideoDecoder(int device_id, OutputSurfaceMemoryType ou
         // start the FFMpeg decoding thread
         ffmpeg_decoder_thread_ = new std::thread(&FFMpegVideoDecoder::DecodeThread, this);
         if (!ffmpeg_decoder_thread_) {
-            THROW("FFMpegVideoDecoder create thread failed");
+            ROCDEC_THROW("FFMpegVideoDecoder create thread failed", -1);
         }
     }
 }
@@ -192,7 +192,7 @@ int FFMpegVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
     if (!dec_context_) {
         dec_context_ = avcodec_alloc_context3(decoder_);        //alloc dec_context_
         if (!dec_context_) {
-            THROW("Could not allocate video codec context");
+            ROCDEC_THROW("Could not allocate video codec context", ROCDEC_RUNTIME_ERROR);
         }
         // set codec to automatically determine how many threads suits best for the decoding job
         dec_context_->thread_count = 0;
@@ -206,7 +206,7 @@ int FFMpegVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
 
         // open the codec
         if (avcodec_open2(dec_context_, decoder_, NULL) < 0) {
-            THROW("Could not open codec");
+            ROCDEC_THROW("Could not open codec", ROCDEC_RUNTIME_ERROR);
         }
         // get the output pixel format from dec_context_
         decoder_pixel_format_ = (dec_context_->pix_fmt == AV_PIX_FMT_NONE) ? AV_PIX_FMT_YUV420P : dec_context_->pix_fmt;

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -27,7 +27,7 @@ RocVideoDecoder::RocVideoDecoder(int device_id, OutputSurfaceMemoryType out_mem_
               device_id_{device_id}, out_mem_type_(out_mem_type), codec_id_(codec), b_force_zero_latency_(force_zero_latency), 
               b_extract_sei_message_(extract_user_sei_Message), disp_delay_(disp_delay), max_width_ (max_width), max_height_(max_height) {
     if (!InitHIP(device_id_)) {
-        THROW("Failed to initilize the HIP");
+        ROCDEC_THROW("Failed to initilize the HIP", ROCDEC_DEVICE_INVALID);
     }
     if (p_crop_rect) crop_rect_ = *p_crop_rect;
     if (b_extract_sei_message_) {
@@ -624,7 +624,7 @@ int RocVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
  */
 int RocVideoDecoder::HandlePictureDecode(RocdecPicParams *pPicParams) {
     if (!roc_decoder_) {
-        THROW("RocDecoder not initialized: failed with ErrCode: " +  TOSTR(ROCDEC_NOT_INITIALIZED));
+        ROCDEC_THROW("RocDecoder not initialized: failed with ErrCode: " +  TOSTR(ROCDEC_NOT_INITIALIZED), ROCDEC_NOT_INITIALIZED);
     }
     pic_num_in_dec_order_[pPicParams->curr_pic_idx] = decode_poc_++;
     ROCDEC_API_CALL(rocDecDecodeFrame(roc_decoder_, pPicParams));
@@ -789,19 +789,19 @@ int RocVideoDecoder::GetSEIMessage(RocdecSeiMessageInfo *pSEIMessageInfo) {
       RocdecSeiMessage *p_sei_msg_info = pSEIMessageInfo->sei_message;
       size_t total_SEI_buff_size = 0;
       if ((pSEIMessageInfo->picIdx < 0) || (pSEIMessageInfo->picIdx >= MAX_FRAME_NUM)) {
-          ERR("Invalid picture index for SEI message: " + TOSTR(pSEIMessageInfo->picIdx));
+          ROCDEC_ERR("Invalid picture index for SEI message: " + TOSTR(pSEIMessageInfo->picIdx));
           return 0;
       }
       for (uint32_t i = 0; i < sei_num_mesages; i++) {
           total_SEI_buff_size += p_sei_msg_info[i].sei_message_size;
       }
       if (!curr_sei_message_ptr_) {
-          ERR("Out of Memory, Allocation failed for m_pCurrSEIMessage");
+          ROCDEC_ERR("Out of Memory, Allocation failed for m_pCurrSEIMessage");
           return 0;
       }
       curr_sei_message_ptr_->sei_data = malloc(total_SEI_buff_size);
       if (!curr_sei_message_ptr_->sei_data) {
-          ERR("Out of Memory, Allocation failed for SEI Buffer");
+          ROCDEC_ERR("Out of Memory, Allocation failed for SEI Buffer");
           return 0;
       }
       memcpy(curr_sei_message_ptr_->sei_data, pSEIMessageInfo->sei_data, total_SEI_buff_size);

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -68,11 +68,11 @@ typedef enum OutputSurfaceMemoryType_enum {
 #define STR(X) std::string(X)
 
 #if DBGINFO
-#define INFO(X) std::clog << "[INF] " << " {" << __func__ <<"} " << " " << X << std::endl;
+#define ROCDEC_INFO(X) std::clog << "[INF] " << " {" << __func__ <<"} " << " " << X << std::endl;
 #else
-#define INFO(X) ;
+#define ROCDEC_INFO(X) ;
 #endif
-#define ERR(X) std::cerr << "[ERR] "  << " {" << __func__ <<"} " << " " << X << std::endl;
+#define ROCDEC_ERR(X) std::cerr << "[ERR] "  << " {" << __func__ <<"} " << " " << X << std::endl;
 
 inline int GetChromaPlaneCount(rocDecVideoSurfaceFormat surface_format) {
     int num_planes = 1;
@@ -128,7 +128,6 @@ private:
 };
 
 #define ROCDEC_THROW(X, CODE) throw RocVideoDecodeException(" { " + std::string(__func__) + " } " + X , CODE);
-#define THROW(X) throw RocVideoDecodeException(" { " + std::string(__func__) + " } " + X);
 
 #define ROCDEC_API_CALL( rocDecAPI )                                                                         \
     do {                                                                                                     \


### PR DESCRIPTION
This avoids bunch of warnings when rocDecode is integrated with rocAL