### PR TITLE
fix for rocPyDecode compilation errors on UB24.04

### DIFF
--- a/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
+++ b/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
@@ -184,7 +184,7 @@ int FFMpegVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
 
     // check if the codec is supported in FFMpeg
     // Initialize FFMpeg and find the decoder for codec
-    if (!decoder_) decoder_ = avcodec_find_decoder(RocDecVideoCodec2AVCodec(p_video_format->codec));
+    if (!decoder_) decoder_ = (AVCodec *) avcodec_find_decoder(RocDecVideoCodec2AVCodec(p_video_format->codec));
     if(!decoder_) {
         ROCDEC_THROW("rocDecode<FFMpeg>:: Codec not supported by FFMpeg ", ROCDEC_NOT_SUPPORTED);
         return 0;

--- a/utils/video_demuxer.h
+++ b/utils/video_demuxer.h
@@ -26,9 +26,9 @@ THE SOFTWARE.
 extern "C" {
     #include <libavcodec/avcodec.h>
     #include <libavformat/avformat.h>
-    #if USE_AVCODEC_GREATER_THAN_58_134
+    //#if USE_AVCODEC_GREATER_THAN_58_134
         #include <libavcodec/bsf.h>
-    #endif
+    //#endif
 }
 
 #include "rocdecode.h"
@@ -473,7 +473,9 @@ class VideoDemuxer {
                         || !strcmp(av_fmt_input_ctx_->iformat->long_name, "Matroska / WebM"));
 
             // Check if the input file allow seek functionality.
-            is_seekable_ = av_fmt_input_ctx_->iformat->read_seek || av_fmt_input_ctx_->iformat->read_seek2;
+            // is_seekable_ = av_fmt_input_ctx_->iformat->read_seek || av_fmt_input_ctx_->iformat->read_seek2;
+            // TODO: find another method to determine if seekable! For now hardcoded to true (ea)
+            is_seekable_ = true;
 
             if (is_h264_) {
                 const AVBitStreamFilter *bsf = av_bsf_get_by_name("h264_mp4toannexb");


### PR DESCRIPTION
Must find alternative to 'seekable' in ffmpeg call as it is removed in recent version.
Casting is needed, it reports error on UB24.04
**USE_AVCODEC_GREATER_THAN_58_134** needs to be re-visited in video_demuxer.h
This PR is needed for rocPyDecode PR: https://github.com/ROCm/rocPyDecode/pull/165 to work correctly.