### PR TITLE
VideoSeekContext - Introduce requested frame pts

### DIFF
--- a/utils/video_demuxer.h
+++ b/utils/video_demuxer.h
@@ -124,6 +124,9 @@ public:
     
     /* DTS of frame to seek as set by the user in seek_frame_. */
     int64_t requested_frame_dts_;
+
+    /* PTS of frame to seek as set by the user in seek_frame_. */
+    int64_t requested_frame_pts_;
 };
 
 
@@ -329,6 +332,7 @@ class VideoDemuxer {
                 seek_ctx.out_frame_pts_ = pkt_data.pts;
                 seek_ctx.out_frame_dts_ = pkt_data.dts;
                 seek_ctx.requested_frame_dts_ = timestamp;
+                seek_ctx.requested_frame_pts_ = (int64_t) (timestamp * default_time_scale_ * time_base_);
                 seek_ctx.out_frame_duration_ = pkt_data.duration = pkt_duration_;
             };
 
@@ -340,6 +344,7 @@ class VideoDemuxer {
                 seek_ctx.out_frame_pts_ = pkt_data.pts;
                 seek_ctx.out_frame_dts_ = pkt_data.dts;
                 seek_ctx.requested_frame_dts_ = timestamp;
+                seek_ctx.requested_frame_pts_ = (int64_t) (timestamp * default_time_scale_ * time_base_);
                 seek_ctx.out_frame_duration_ = pkt_data.duration = pkt_duration_;
             };
 

--- a/utils/video_demuxer.h
+++ b/utils/video_demuxer.h
@@ -116,15 +116,6 @@ public:
     /* Number of frames that were decoded during seek. */
     uint64_t num_frames_decoded_;
 
-    /* DTS of frame found after seek.
-     * In case the requested frame is not seekable, the demuxer will seek
-     * to the nearest seekable frame and its DTS is stored in out_frame_dts_.
-     */ 
-    int64_t out_frame_dts_;
-    
-    /* DTS of frame to seek as set by the user in seek_frame_. */
-    int64_t requested_frame_dts_;
-
     /* PTS of frame to seek as set by the user in seek_frame_. */
     int64_t requested_frame_pts_;
 };
@@ -164,7 +155,7 @@ class VideoDemuxer {
                 av_free(data_with_header_);
             }
         }
-        bool Demux(uint8_t **video, int *video_size, int64_t *pts = nullptr, int64_t *dts = nullptr) {
+        bool Demux(uint8_t **video, int *video_size, int64_t *pts = nullptr) {
             if (!av_fmt_input_ctx_) {
                 return false;
             }
@@ -202,7 +193,6 @@ class VideoDemuxer {
                     *pts = (int64_t) (packet_filtered_->pts * default_time_scale_ * time_base_);
                     pkt_duration_ = packet_filtered_->duration;
                 }
-                if (dts) *dts = pkt_dts_;
             } else {
                 if (is_mpeg4_ && (frame_count_ == 0)) {
                     int ext_data_size = av_fmt_input_ctx_->streams[av_stream_]->codecpar->extradata_size;
@@ -230,7 +220,6 @@ class VideoDemuxer {
                     *pts = (int64_t)(packet_->pts * default_time_scale_ * time_base_);
                     pkt_duration_ = packet_->duration;
                 }
-                if (dts) *dts = pkt_dts_;
             }
             frame_count_++;
             return true;
@@ -252,7 +241,6 @@ class VideoDemuxer {
                 std::cerr << "ERROR: Can't seek by frame number in VFR sequences. Seek by timestamp instead." << std::endl;
                 return false;
             }
-
             int64_t timestamp = 0;
             // Seek for single frame;
             auto seek_frame = [&](VideoSeekContext const& seek_ctx, int flags) {
@@ -312,7 +300,7 @@ class VideoDemuxer {
 
                 int seek_done = 0;
                 do {
-                    if (!Demux(pp_video, video_size, &pkt_data.pts, &pkt_data.dts)) {
+                    if (!Demux(pp_video, video_size, &pkt_data.pts)) {
                         throw std::runtime_error("ERROR: Demux failed trying to seek for specified frame number/timestamp");
                     }
                     seek_done = is_seek_done(pkt_data, seek_ctx);
@@ -330,22 +318,18 @@ class VideoDemuxer {
                 } while (seek_done != 0);
 
                 seek_ctx.out_frame_pts_ = pkt_data.pts;
-                seek_ctx.out_frame_dts_ = pkt_data.dts;
-                seek_ctx.requested_frame_dts_ = timestamp;
-                seek_ctx.requested_frame_pts_ = (int64_t) (timestamp * default_time_scale_ * time_base_);
                 seek_ctx.out_frame_duration_ = pkt_data.duration = pkt_duration_;
+                seek_ctx.requested_frame_pts_ = (int64_t) (timestamp * default_time_scale_ * time_base_);
             };
 
             // Seek for closest key frame in the past;
             auto seek_for_prev_key_frame = [&](PacketData& pkt_data, VideoSeekContext& seek_ctx) {
                 seek_frame(seek_ctx, AVSEEK_FLAG_BACKWARD);
-                Demux(pp_video, video_size, &pkt_data.pts, &pkt_data.dts);
+                Demux(pp_video, video_size, &pkt_data.pts);
                 seek_ctx.num_frames_decoded_ = static_cast<uint64_t>(pkt_data.pts / 1000 * frame_rate_);
                 seek_ctx.out_frame_pts_ = pkt_data.pts;
-                seek_ctx.out_frame_dts_ = pkt_data.dts;
-                seek_ctx.requested_frame_dts_ = timestamp;
-                seek_ctx.requested_frame_pts_ = (int64_t) (timestamp * default_time_scale_ * time_base_);
                 seek_ctx.out_frame_duration_ = pkt_data.duration = pkt_duration_;
+                seek_ctx.requested_frame_pts_ = (int64_t) (timestamp * default_time_scale_ * time_base_);
             };
 
             PacketData pktData;


### PR DESCRIPTION
- Remove args and member variables related to DTS
- Add support to store the PTS of the requested frame in seek
- To be used in rocAL to seek to the correct frame before decoding