### PR TITLE
Warning fixes

### DIFF
--- a/samples/videoDecodeRGB/CMakeLists.txt
+++ b/samples/videoDecodeRGB/CMakeLists.txt
@@ -61,17 +61,20 @@ else()
 endif()
 
 # Set supported GPU Targets
-find_package(ROCmCMakeBuildTools)
-#include( ROCMSetupVersion )
-include( ROCMCreatePackage )
-message("-- ROCm Version Found: ${ROCM_PLATFORM_VERSION}")
-set(GPU_TARGETS_ROCM_6.3 "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
-set(GPU_TARGETS_ROCM_6.4 "gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
 
-if(${ROCM_PLATFORM_VERSION} GREATER_EQUAL 6.1.0 AND ${ROCM_PLATFORM_VERSION} LESS_EQUAL 6.3.0)
-    set(DEFAULT_GPU_TARGETS "${GPU_TARGETS_ROCM_6.3}")
-elseif(${ROCM_PLATFORM_VERSION} GREATER_EQUAL 6.4.0)
-    set(DEFAULT_GPU_TARGETS "${GPU_TARGETS_ROCM_6.4}")
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1200;gfx1201")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
 endif()
 
 # Set AMD GPU_TARGETS

--- a/samples/videoDecodeRGB/CMakeLists.txt
+++ b/samples/videoDecodeRGB/CMakeLists.txt
@@ -61,7 +61,18 @@ else()
 endif()
 
 # Set supported GPU Targets
-set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
+find_package(ROCmCMakeBuildTools)
+#include( ROCMSetupVersion )
+include( ROCMCreatePackage )
+message("-- ROCm Version Found: ${ROCM_PLATFORM_VERSION}")
+set(GPU_TARGETS_ROCM_6.3 "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
+set(GPU_TARGETS_ROCM_6.4 "gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
+
+if(${ROCM_PLATFORM_VERSION} GREATER_EQUAL 6.1.0 AND ${ROCM_PLATFORM_VERSION} LESS_EQUAL 6.3.0)
+    set(DEFAULT_GPU_TARGETS "${GPU_TARGETS_ROCM_6.3}")
+elseif(${ROCM_PLATFORM_VERSION} GREATER_EQUAL 6.4.0)
+    set(DEFAULT_GPU_TARGETS "${GPU_TARGETS_ROCM_6.4}")
+endif()
 
 # Set AMD GPU_TARGETS
 if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -1076,6 +1076,10 @@ void RocVideoDecoder::WaitForDecodeCompletion() {
     RocdecDecodeStatus dec_status;
     memset(&dec_status, 0, sizeof(dec_status));
     do {
-        (void)rocDecGetDecodeStatus(roc_decoder_, last_decode_surf_idx_, &dec_status);
+        rocDecStatus result = rocDecGetDecodeStatus(roc_decoder_, last_decode_surf_idx_, &dec_status);
+        if (result != ROCDEC_SUCCESS) {
+            std::cerr << "rocDecGetDecodeStatus failed for picture_index: " << last_decode_surf_idx_ << std::endl;
+            return;
+        }
     } while (dec_status.decode_status == rocDecodeStatus_InProgress);
 }

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -660,7 +660,7 @@ int RocVideoDecoder::HandlePictureDisplay(RocdecParserDispInfo *pDispInfo) {
             RocdecSeiMessage *sei_message = sei_message_display_q_[pDispInfo->picture_index].sei_message;
             if (fp_sei_) {
                 for (uint32_t i = 0; i < sei_num_messages; i++) {
-                    if (codec_id_ == rocDecVideoCodec_AVC || rocDecVideoCodec_HEVC) {
+                    if (codec_id_ == rocDecVideoCodec_AVC || codec_id_ == rocDecVideoCodec_HEVC) {
                         switch (sei_message[i].sei_message_type) {
                             case SEI_TYPE_TIME_CODE: {
                                 //todo:: check if we need to write timecode
@@ -882,7 +882,6 @@ bool RocVideoDecoder::ReleaseFrame(int64_t pTimestamp, bool b_flushing) {
     if (!vp_frames_q_.empty()) {
         std::lock_guard<std::mutex> lock(mtx_vp_frame_);
         DecFrameBuffer *fb = &vp_frames_q_.front();
-        void *mapped_frame_ptr = fb->frame_ptr;
 
         if (pTimestamp != fb->pts) {
             std::cerr << "Decoded Frame is released out of order" << std::endl;
@@ -1077,6 +1076,6 @@ void RocVideoDecoder::WaitForDecodeCompletion() {
     RocdecDecodeStatus dec_status;
     memset(&dec_status, 0, sizeof(dec_status));
     do {
-        rocDecStatus result = rocDecGetDecodeStatus(roc_decoder_, last_decode_surf_idx_, &dec_status);
+        (void)rocDecGetDecodeStatus(roc_decoder_, last_decode_surf_idx_, &dec_status);
     } while (dec_status.decode_status == rocDecodeStatus_InProgress);
 }

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -473,15 +473,15 @@ class RocVideoDecoder {
         RocdecVideoParser rocdec_parser_ = nullptr;
         rocDecDecoderHandle roc_decoder_ = nullptr;
         OutputSurfaceMemoryType out_mem_type_ = OUT_SURFACE_MEM_DEV_INTERNAL;
-        bool b_extract_sei_message_ = false;
+        rocDecVideoCodec codec_id_ = rocDecVideoCodec_NumCodecs;
         bool b_force_zero_latency_ = false;
+        bool b_extract_sei_message_ = false;
         uint32_t disp_delay_;
         ReconfigParams *p_reconfig_params_ = nullptr;
         bool b_force_recofig_flush_ = false;
         int32_t num_frames_flushed_during_reconfig_ = 0;
         hipDeviceProp_t hip_dev_prop_;
         hipStream_t hip_stream_;
-        rocDecVideoCodec codec_id_ = rocDecVideoCodec_NumCodecs;
         rocDecVideoChromaFormat video_chroma_format_ = rocDecVideoChromaFormat_420;
         rocDecVideoSurfaceFormat video_surface_format_ = rocDecVideoSurfaceFormat_NV12;
         RocdecSeiMessageInfo *curr_sei_message_ptr_ = nullptr;


### PR DESCRIPTION
Noticed some warnings while building rocAL like below. This PR fixes these 
```
[  4%] Building CXX object rocAL/CMakeFiles/rocal.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp:27:67: warning: initializer order does not match the declaration order [-Wreorder-ctor]
   27 |               device_id_{device_id}, out_mem_type_(out_mem_type), codec_id_(codec), b_force_zero_latency_(force_zero_latency),
      |                                                                   ^~~~~~~~~~~~~~~~
      |                                                                   b_extract_sei_message_(extract_user_sei_Message)
   28 |               b_extract_sei_message_(extract_user_sei_Message), disp_delay_(disp_delay), max_width_ (max_width), max_height_(max_height) {
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~~~
      |               disp_delay_(disp_delay)                           codec_id_(codec)
/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp:27:67: note: field 'codec_id_' will be initialized after field 'b_force_zero_latency_'
   27 |               device_id_{device_id}, out_mem_type_(out_mem_type), codec_id_(codec), b_force_zero_latency_(force_zero_latency),
      |                                                                   ^~~~~~~~~~~~~~~~
/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp:27:85: note: field 'b_force_zero_latency_' will be initialized after field 'b_extract_sei_message_'
   27 |               device_id_{device_id}, out_mem_type_(out_mem_type), codec_id_(codec), b_force_zero_latency_(force_zero_latency),
      |                                                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp:663:59: warning: converting the enum constant to a boolean [-Wint-in-bool-context]
  663 |                     if (codec_id_ == rocDecVideoCodec_AVC || rocDecVideoCodec_HEVC) {
      |                                                           ^
/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp:885:15: warning: unused variable 'mapped_frame_ptr' [-Wunused-variable]
  885 |         void *mapped_frame_ptr = fb->frame_ptr;
      |               ^~~~~~~~~~~~~~~~
/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp:1080:22: warning: unused variable 'result' [-Wunused-variable]
 1080 |         rocDecStatus result = rocDecGetDecodeStatus(roc_decoder_, last_decode_surf_idx_, &dec_status);
      |                      ^~~~~~
In file included from /home/lakshmi/work/rocAL/rocAL/source/decoders/video/rocdec_video_decoder.cpp:23:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/iomanip:40:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/ios_base.h:41:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/locale_classes.h:40:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/string:53:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/basic_string.h:39:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/ext/alloc_traits.h:34:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/alloc_traits.h:33:
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_construct.h:151:7: warning: destructor called on non-final 'RocVideoDecoder' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
  151 |       __pointer->~_Tp();
      |       ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/alloc_traits.h:648:9: note: in instantiation of function template specialization 'std::_Destroy<RocVideoDecoder>' requested here
  648 |         { std::_Destroy(__p); }
      |                ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:613:28: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<void>>::destroy<RocVideoDecoder>' requested here
  613 |         allocator_traits<_Alloc>::destroy(_M_impl._M_alloc(), _M_ptr());
      |                                   ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:599:2: note: in instantiation of member function 'std::_Sp_counted_ptr_inplace<RocVideoDecoder, std::allocator<void>, __gnu_cxx::_S_atomic>::_M_dispose' requested here
  599 |         _Sp_counted_ptr_inplace(_Alloc __a, _Args&&... __args)
      |         ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:972:6: note: in instantiation of function template specialization 'std::_Sp_counted_ptr_inplace<RocVideoDecoder, std::allocator<void>, __gnu_cxx::_S_atomic>::_Sp_counted_ptr_inplace<int &, OutputSurfaceMemoryType_enum &, rocDecVideoCodec_enum &, int, std::nullptr_t, int>' requested here
  972 |             _Sp_cp_type(__a._M_a, std::forward<_Args>(__args)...);
      |             ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr_base.h:1712:14: note: in instantiation of function template specialization 'std::__shared_count<>::__shared_count<RocVideoDecoder, std::allocator<void>, int &, OutputSurfaceMemoryType_enum &, rocDecVideoCodec_enum &, int, std::nullptr_t, int>' requested here
 1712 |         : _M_ptr(), _M_refcount(_M_ptr, __tag, std::forward<_Args>(__args)...)
      |                     ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr.h:464:4: note: in instantiation of function template specialization 'std::__shared_ptr<RocVideoDecoder>::__shared_ptr<std::allocator<void>, int &, OutputSurfaceMemoryType_enum &, rocDecVideoCodec_enum &, int, std::nullptr_t, int>' requested here
  464 |         : __shared_ptr<_Tp>(__tag, std::forward<_Args>(__args)...)
      |           ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/shared_ptr.h:1009:14: note: in instantiation of function template specialization 'std::shared_ptr<RocVideoDecoder>::shared_ptr<std::allocator<void>, int &, OutputSurfaceMemoryType_enum &, rocDecVideoCodec_enum &, int, std::nullptr_t, int>' requested here
 1009 |       return shared_ptr<_Tp>(_Sp_alloc_shared_tag<_Alloc>{__a},
      |              ^
/home/lakshmi/work/rocAL/rocAL/source/decoders/video/rocdec_video_decoder.cpp:71:28: note: in instantiation of function template specialization 'std::make_shared<RocVideoDecoder, int &, OutputSurfaceMemoryType_enum &, rocDecVideoCodec_enum &, int, std::nullptr_t, int>' requested here
   71 |     _rocvid_decoder = std::make_shared<RocVideoDecoder>(device_id, mem_type, rocdec_codec_id, 0, nullptr, 0);
      |                            ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_construct.h:151:19: note: qualify call to silence this warning
  151 |       __pointer->~_Tp();
      |                   ^
1 warning generated.
4 warnings generated.
[  4%] Linking CXX shared library ../lib/librocal.so
[ 97%] Built target rocal
[ 98%] Building CXX object rocAL_pybind/CMakeFiles/rocal_pybind.dir/rocal_pybind.cpp.o
[100%] Linking CXX shared module ../rocal_pybind/lib/rocal_pybind.cpython-310-x86_64-linux-gnu.so
[100%] Built target rocal_pybind
```