### PR TITLE
Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(HIP_FOUND AND Libva_FOUND)
   # rocdecode.so
   add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17 -Wall")
   target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})
 
   set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/amd_detail/rocdecode_api_trace.cpp
+++ b/src/amd_detail/rocdecode_api_trace.cpp
@@ -91,7 +91,7 @@ template <typename Tp> void ToolInit(Tp* table) {
 #if ROCDECODE_ROCPROFILER_REGISTER > 0
     auto table_array = std::array<void*, 1>{static_cast<void*>(table)};
     auto lib_id = rocprofiler_register_library_indentifier_t{};
-    auto rocp_reg_status = rocprofiler_register_library_api_table(
+    rocprofiler_register_library_api_table(
         dispatch_table_info<Tp>::name, dispatch_table_info<Tp>::import_func,
         dispatch_table_info<Tp>::version, table_array.data(), table_array.size(), &lib_id);
 #else

--- a/src/amd_detail/rocdecode_api_trace.cpp
+++ b/src/amd_detail/rocdecode_api_trace.cpp
@@ -84,10 +84,6 @@ template <> struct dispatch_table_info<TYPE> { \
     static constexpr auto import_func = &ROCPROFILER_REGISTER_IMPORT_FUNC(NAME); \
 };
 
-constexpr auto ComputeTableSize(size_t num_funcs) {
-    return (num_funcs * sizeof(void*)) + sizeof(uint64_t);
-}
-
 ROCDECODE_DEFINE_DISPATCH_TABLE_INFO(RocDecodeDispatchTable, rocdecode)
 #endif
 

--- a/src/bit_stream_reader/es_reader.cpp
+++ b/src/bit_stream_reader/es_reader.cpp
@@ -425,44 +425,6 @@ int RocVideoESParser::GetPicDataAv1(uint8_t **p_pic_data, int *pic_size) {
     return 0;
 }
 
-bool RocVideoESParser::CheckIvfFileHeader(uint8_t *stream) {
-    static const char *IVF_SIGNATURE = "DKIF";
-    uint8_t *ptr = stream;
-
-    // bytes 0-3: signature
-    if (memcmp(IVF_SIGNATURE, ptr, 4) == 0) {
-        ptr += 4;
-        // bytes 4-5: version (should be 0). Little Endian.
-        int ivf_version = ptr[0] | (ptr[1] << 8);
-        if (ivf_version != 0) {
-            ERR("Stream file error: Incorrect IVF version (" + TOSTR(ivf_version) + "). Should be 0.");
-        }
-        // bytes 6-7: length of header in bytes
-        ptr += 4;
-        // bytes 8-11: codec FourCC (e.g., 'AV01')
-        uint32_t codec_fourcc = ptr[0] | (ptr[1] << 8) | (ptr[2] << 16) | (ptr[3] << 24);
-        ptr += 4;
-        // bytes 12-13: width in pixels
-        uint32_t width = ptr[0] | (ptr[1] << 8);
-        ptr += 2;
-        // bytes 14-15: height in pixels
-        uint32_t height = ptr[0] | (ptr[1] << 8);
-        ptr += 2;
-        // bytes 16-23: time base denominator
-        uint32_t denominator = ptr[0] | (ptr[1] << 8) | (ptr[2] << 16) | (ptr[3] << 24);
-        ptr += 4;
-        // bytes 20-23: time base numerator
-        uint32_t numerator = ptr[0] | (ptr[1] << 8) | (ptr[2] << 16) | (ptr[3] << 24);
-        ptr += 4;
-        // bytes 24-27: number of frames in file
-        uint32_t num_frames = ptr[0] | (ptr[1] << 8);
-        // bytes 28-31: unused
-        return true;
-    } else {
-        return false;
-    }
-}
-
 int RocVideoESParser::GetPicDataIvf(uint8_t **p_pic_data, int *pic_size) {
     uint8_t frame_header[12];
     pic_data_size_ = 0;
@@ -1165,7 +1127,6 @@ int RocVideoESParser::CheckIvfAv1Stream(uint8_t *p_stream, int stream_size) {
 
 int RocVideoESParser::CheckVp9EStream(uint8_t *p_stream, int stream_size) {
     int score = 0;
-    int curr_offset = 0; // byte offset
     size_t offset = 0; // bit offset
     Vp9UncompressedHeader uncomp_header;
 

--- a/src/bit_stream_reader/es_reader.h
+++ b/src/bit_stream_reader/es_reader.h
@@ -182,11 +182,6 @@ class RocVideoESParser {
          */
         bool CopyObuFromRing();
 
-        /*! \brief Function to check the 32 byte stream for IVF file header identity
-         * \return true if IVF file header is identified; false: otherwise
-         */
-        bool CheckIvfFileHeader(uint8_t *stream);
-
         /*! \brief Function to probe the bitstream file and try to find if it is one of types supported.
          * \return Elementary stream file type
          */

--- a/src/parser/av1_parser.cpp
+++ b/src/parser/av1_parser.cpp
@@ -1228,7 +1228,6 @@ ParserResult Av1VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
 
 void Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
     size_t offset = 0;  // current bit offset
-    Av1SequenceHeader *p_seq_header = &seq_header_;
     Av1FrameHeader *p_frame_header = &frame_header_;
     Av1TileGroupDataInfo *p_tile_group = &tile_group_data_;
     uint32_t tile_start_and_end_present_flag = 0;

--- a/src/parser/avc_parser.cpp
+++ b/src/parser/avc_parser.cpp
@@ -39,7 +39,7 @@ AvcVideoParser::AvcVideoParser() {
     curr_ref_pic_bottom_field_ = 0;
     max_long_term_frame_idx_ = NO_LONG_TERM_FRAME_INDICES;
 
-    slice_info_list_.assign(INIT_SLICE_LIST_NUM, {0});
+    slice_info_list_.assign(INIT_SLICE_LIST_NUM, {{0}});
     slice_param_list_.assign(INIT_SLICE_LIST_NUM, {0});
     memset(&curr_pic_, 0, sizeof(AvcPicture));
     field_pic_count_ = 0;
@@ -183,7 +183,7 @@ ParserResult AvcVideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
 
                     // Resize slice info list if needed
                     if ((num_slices_ + 1) > slice_info_list_.size()) {
-                        slice_info_list_.resize(num_slices_ + 1, {0});
+                        slice_info_list_.resize(num_slices_ + 1, {{0}});
                     }
 
                     slice_info_list_[num_slices_].slice_data_offset = curr_start_code_offset_;
@@ -988,28 +988,6 @@ ParserResult AvcVideoParser::ParsePps(uint8_t *p_stream, size_t stream_size_in_b
         // Note: VCN supports High Profile only (num_slice_groups_minus1 = 0)
         ERR("Multiple slice groups are not supported");
         return PARSER_NOT_SUPPORTED;
-
-        p_pps->slice_group_map_type = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        if (p_pps->slice_group_map_type == 0) {
-            for (int i_group = 0; i_group <= p_pps->num_slice_groups_minus1; i_group++) {
-                p_pps->run_length_minus1[i_group] = Parser::ExpGolomb::ReadUe(p_stream, offset);
-            }
-        } else if (p_pps->slice_group_map_type == 2) {
-            for (int i_group = 0; i_group < p_pps->num_slice_groups_minus1; i_group++ ) {
-                p_pps->top_left[i_group] = Parser::ExpGolomb::ReadUe(p_stream, offset);
-                p_pps->bottom_right[i_group] = Parser::ExpGolomb::ReadUe(p_stream, offset);
-            }
-        } else if (p_pps->slice_group_map_type == 3 || p_pps->slice_group_map_type == 4 || p_pps->slice_group_map_type == 5) {
-            p_pps->slice_group_change_direction_flag = Parser::GetBit(p_stream, offset);
-            p_pps->slice_group_change_rate_minus1 = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        } else if (p_pps->slice_group_map_type == 6) {
-            p_pps->pic_size_in_map_units_minus1 = Parser::ExpGolomb::ReadUe(p_stream, offset);
-            int slice_group_id_size = ceil(log2(p_pps->num_slice_groups_minus1 + 1));
-            for (int i = 0; i <= p_pps->pic_size_in_map_units_minus1; i++) {
-                int temp = Parser::ReadBits(p_stream, offset, slice_group_id_size);
-                ERR("AVC PPS parsing: slice_group_id memory not allocaed!");
-            }
-        }
     }
 
     p_pps->num_ref_idx_l0_default_active_minus1 = Parser::ExpGolomb::ReadUe(p_stream, offset);
@@ -1812,7 +1790,6 @@ ParserResult AvcVideoParser::DecodeFrameNumGaps() {
             non_existing_pic.pic_output_flag = 0;
 
             // Calculate POC
-            int max_pic_order_cnt_lsb = 1 << (p_sps->log2_max_pic_order_cnt_lsb_minus4 + 4); // MaxPicOrderCntLsb
             int frame_num_offset; // FrameNumOffset
             if (p_sps->pic_order_cnt_type == 0) {
                 // -1 is to try to avoid generating POC for the non-existing reference frames the same value as the existing ref.
@@ -2157,7 +2134,7 @@ ParserResult AvcVideoParser::SetupReflist(AvcSliceInfo *p_slice_info) {
             }
         } else { // 8.2.4.2.2 Initialisation process for the reference picture list for P and SP slices in fields
             // Construct and sort refFrameList0ShortTerm
-            AvcPicture ref_frame_list0_short_term[AVC_MAX_REF_FRAME_NUM] = {0};
+            AvcPicture ref_frame_list0_short_term[AVC_MAX_REF_FRAME_NUM] = {{0}};
             int index = 0;
             for (i = 0; i < dpb_buffer_.dpb_size; i++) {
                 if (dpb_buffer_.field_pic_list[i * 2].is_reference == kUsedForShortTerm || dpb_buffer_.field_pic_list[i * 2 + 1].is_reference == kUsedForShortTerm) {
@@ -2173,7 +2150,7 @@ ParserResult AvcVideoParser::SetupReflist(AvcSliceInfo *p_slice_info) {
             FillFieldRefList(ref_frame_list0_short_term, index, kUsedForShortTerm, curr_pic_.pic_structure, p_slice_info->ref_list_0_, &dpb_buffer_.num_short_term_ref_fields);
 
             // Construct and sort refFrameList0LongTerm
-            AvcPicture ref_frame_list0_long_term[AVC_MAX_REF_FRAME_NUM] = {0};
+            AvcPicture ref_frame_list0_long_term[AVC_MAX_REF_FRAME_NUM] = {{0}};
             index = 0;
             for (i = 0; i < dpb_buffer_.dpb_size; i++) {
                 if (dpb_buffer_.field_pic_list[i * 2].is_reference == kUsedForLongTerm || dpb_buffer_.field_pic_list[i * 2 + 1].is_reference == kUsedForLongTerm) {
@@ -2290,7 +2267,7 @@ ParserResult AvcVideoParser::SetupReflist(AvcSliceInfo *p_slice_info) {
             // RefPicList0
             // ===========
             // Construct and sort refFrameList0ShortTerm
-            AvcPicture ref_frame_list0_short_term[AVC_MAX_REF_FRAME_NUM] = {0};
+            AvcPicture ref_frame_list0_short_term[AVC_MAX_REF_FRAME_NUM] = {{0}};
             int num_short_term_smaller = 0;
             int num_short_term_greater = 0;
             int index = 0;
@@ -2322,7 +2299,7 @@ ParserResult AvcVideoParser::SetupReflist(AvcSliceInfo *p_slice_info) {
             FillFieldRefList(ref_frame_list0_short_term, num_short_term_smaller + num_short_term_greater, kUsedForShortTerm, curr_pic_.pic_structure, p_slice_info->ref_list_0_, &dpb_buffer_.num_short_term_ref_fields);
 
             // Construct and sort refFrameListLongTerm
-            AvcPicture ref_frame_list_long_term[AVC_MAX_REF_FRAME_NUM] = {0};
+            AvcPicture ref_frame_list_long_term[AVC_MAX_REF_FRAME_NUM] = {{0}};
             int num_long_term = 0;
             index = 0;
             for (i = 0; i < dpb_buffer_.dpb_size; i++) {
@@ -2344,7 +2321,7 @@ ParserResult AvcVideoParser::SetupReflist(AvcSliceInfo *p_slice_info) {
             // RefPicList1
             // ===========
             // Construct and sort refFrameList1ShortTerm
-            AvcPicture ref_frame_list1_short_term[AVC_MAX_REF_FRAME_NUM] = {0};
+            AvcPicture ref_frame_list1_short_term[AVC_MAX_REF_FRAME_NUM] = {{0}};
             num_short_term_smaller = 0;
             num_short_term_greater = 0;
             index = 0;

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -27,7 +27,7 @@ HevcVideoParser::HevcVideoParser() {
     m_active_vps_id_ = -1; 
     m_active_sps_id_ = -1;
     m_active_pps_id_ = -1;
-    slice_info_list_.assign(INIT_SLICE_LIST_NUM, {0});
+    slice_info_list_.assign(INIT_SLICE_LIST_NUM, {{0}});
     slice_param_list_.assign(INIT_SLICE_LIST_NUM, {0});
     memset(&curr_pic_info_, 0, sizeof(HevcPicInfo));
     for (int i = 0; i < MAX_VPS_COUNT; i++) {
@@ -593,7 +593,7 @@ ParserResult HevcVideoParser::ParsePictureData(const uint8_t* p_stream, uint32_t
 
                     // Resize slice info list if needed
                     if ((num_slices_ + 1) > slice_info_list_.size()) {
-                        slice_info_list_.resize(num_slices_ + 1, {0});
+                        slice_info_list_.resize(num_slices_ + 1, {{0}});
                     }
 
                     slice_info_list_[num_slices_].slice_data_offset = curr_start_code_offset_;
@@ -2106,7 +2106,7 @@ void HevcVideoParser::DecodeRps() {
 void HevcVideoParser::ConstructRefPicLists(HevcSliceInfo *p_slice_info) {
     HevcSliceSegHeader *p_slice_header = &p_slice_info->slice_header;
     uint32_t num_rps_curr_temp_list; // NumRpsCurrTempList0 or NumRpsCurrTempList1;
-    int i, j;
+    int i;
     int rIdx;
     uint32_t ref_pic_list_temp[HEVC_MAX_NUM_REF_PICS] = {0};  // RefPicListTemp0 or RefPicListTemp1
 
@@ -2275,7 +2275,7 @@ ParserResult HevcVideoParser::FindFreeInDecBufPool() {
 }
 
 ParserResult HevcVideoParser::FindFreeInDpbAndMark() {
-    int i, j;
+    int i;
 
     // Look for an empty buffer in DPB with longest decode history (lowest decode count)
     uint32_t min_decode_order_count = 0xFFFFFFFF;

--- a/src/rocdecode/roc_decoder.h
+++ b/src/rocdecode/roc_decoder.h
@@ -56,8 +56,7 @@ public:
 
 private:
     rocDecStatus FreeVideoFrame(int pic_idx);
-    int num_devices_;
-    RocDecoderCreateInfo decoder_create_info_;
     VaapiVideoDecoder va_video_decoder_;
+    RocDecoderCreateInfo decoder_create_info_;
     std::vector<HipInteropDeviceMem> hip_interop_;
 };

--- a/src/rocdecode/vaapi/vaapi_videodecoder.h
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.h
@@ -103,9 +103,9 @@ private:
     RocDecoderCreateInfo decoder_create_info_;
     int drm_fd_;
     VADisplay va_display_;
-    VAProfile va_profile_;
     VAConfigAttrib va_config_attrib_;
     VAConfigID va_config_id_;
+    VAProfile va_profile_;
     VAContextID va_context_id_;
     std::vector<VASurfaceID> va_surface_ids_;
     bool supports_modifiers_;
@@ -115,7 +115,6 @@ private:
     std::vector<VABufferID> slice_params_buf_id_ = std::vector<VABufferID>(INIT_SLICE_PARAM_LIST_NUM, 0);
     uint32_t num_slices_;
     VABufferID slice_data_buf_id_;
-    uint32_t slice_data_buf_size_;
 
     bool IsCodecConfigSupported(int device_id, rocDecVideoCodec codec_type, rocDecVideoChromaFormat chroma_format, uint32_t bit_depth_minus8, rocDecVideoSurfaceFormat output_format);
     rocDecStatus CreateDecoderConfig();

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -217,8 +217,8 @@ class RocVideoDecoder {
         RocVideoDecoder(int device_id,  OutputSurfaceMemoryType out_mem_type, rocDecVideoCodec codec, bool force_zero_latency = false,
                           const Rect *p_crop_rect = nullptr, bool extract_user_SEI_Message = false, uint32_t disp_delay = 0, int max_width = 0, int max_height = 0,
                           uint32_t clk_rate = 1000);
-        ~RocVideoDecoder();
-        
+        virtual ~RocVideoDecoder();
+
         rocDecVideoCodec GetCodecId() { return codec_id_; }
 
         /**


### PR DESCRIPTION
Added flag `-Wall` to CMakeLists.txt to catch warnings here, instead of catching them in rocAL.
Resolved most warnings after talking to Jeff.
@AryanSalmanpour I need help with just this part
```
lakshmi@kapu:~/work/lk/rocDecode/build$ make -j
Consolidate compiler generated dependencies of target rocdecode
[  7%] Building CXX object CMakeFiles/rocdecode.dir/src/amd_detail/rocdecode_api_trace.cpp.o
/home/lakshmi/work/lk/rocDecode/src/amd_detail/rocdecode_api_trace.cpp:94:10: warning: unused variable 'rocp_reg_status' [-Wunused-variable]
   94 |     auto rocp_reg_status = rocprofiler_register_library_api_table(
      |          ^~~~~~~~~~~~~~~
/home/lakshmi/work/lk/rocDecode/src/amd_detail/rocdecode_api_trace.cpp:107:5: note: in instantiation of function template specialization 'rocdecode::(anonymous namespace)::ToolInit<RocDecodeDispatchTable>' requested here
  107 |     ToolInit(&dispatch_table);
      |     ^
/home/lakshmi/work/lk/rocDecode/src/amd_detail/rocdecode_api_trace.cpp:113:46: note: in instantiation of function template specialization 'rocdecode::(anonymous namespace)::GetDispatchTableImpl<RocDecodeDispatchTable>' requested here
  113 |     static auto* rocdecode_dispatch_table = &GetDispatchTableImpl<RocDecodeDispatchTable>();
      |                                              ^
1 warning generated.
[ 14%] Linking CXX shared library lib/librocdecode.so
[100%] Built target rocdecode
```

Fixes issue: https://github.com/ROCm/rocAL/issues/282
