### PR TITLE
HEVC error resilience: Adjusted the range check for the total reference picture number so more errors can be detected.

### DIFF
--- a/src/parser/avc_parser.cpp
+++ b/src/parser/avc_parser.cpp
@@ -3281,7 +3281,7 @@ void AvcVideoParser::PrintPps(AvcPicParameterSet *p_pps) {
 }
 
 void AvcVideoParser::PrintSliceHeader(AvcSliceHeader *p_slice_header) {
-    uint32_t i, j;
+    uint32_t j;
         
     MSG("======================");
     MSG("Slice header");

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -1805,7 +1805,7 @@ ParserResult HevcVideoParser::ParseSliceHeader(uint8_t *nalu, size_t size, HevcS
                 }
             }
             if (p_slice_header->slice_type != HEVC_SLICE_TYPE_I) {
-                CHECK_ALLOWED_RANGE("num_of_delta_pocs + num_long_term_pics", p_slice_header->st_rps.num_of_delta_pocs + p_slice_header->num_long_term_pics, 1, dpb_buffer_.dpb_size);
+                CHECK_ALLOWED_RANGE("num_of_delta_pocs + num_long_term_pics", p_slice_header->st_rps.num_of_delta_pocs + p_slice_header->num_long_term_pics, 1, dpb_buffer_.dpb_size - 1);
             }
             if (sps_ptr->sps_temporal_mvp_enabled_flag) {
                 p_slice_header->slice_temporal_mvp_enabled_flag = Parser::GetBit(nalu, offset);


### PR DESCRIPTION
- Also fixed a build warning of avc_parser.cpp in debug mode.