### PR TITLE
AVC: Fixed an issue in video size change cases, where the remaining decoded buffers of the previous video size in DPB are not output.

### DIFF
--- a/src/parser/avc_parser.cpp
+++ b/src/parser/avc_parser.cpp
@@ -71,6 +71,9 @@ rocDecStatus AvcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
 
         // Init Roc decoder for the first time or reconfigure the existing decoder
         if (new_seq_activated_) {
+            if (FlushDpb() != PARSER_OK) {
+                return ROCDEC_RUNTIME_ERROR;
+            }
             if (NotifyNewSps(&sps_list_[active_sps_id_]) != PARSER_OK) {
                 return ROCDEC_RUNTIME_ERROR;
             }
@@ -2632,7 +2635,7 @@ ParserResult AvcVideoParser::MarkDecodedRefPics() {
         }
         // Output the remaining picutres in DPB
         if (FlushDpb() != PARSER_OK) {
-                return PARSER_FAIL;
+            return PARSER_FAIL;
         }
         dpb_buffer_.num_long_term = 0;
         dpb_buffer_.num_short_term = 0;


### PR DESCRIPTION
 - We need to flush DPB before decoder reconfiguration.