### PR TITLE
Add extra error checking during decoder reconfiguration

### DIFF
--- a/src/rocdecode/roc_decoder.cpp
+++ b/src/rocdecode/roc_decoder.cpp
@@ -82,7 +82,8 @@ rocDecStatus RocDecoder::GetDecodeStatus(int pic_idx, RocdecDecodeStatus* decode
 }
 
 rocDecStatus RocDecoder::ReconfigureDecoder(RocdecReconfigureDecoderInfo *reconfig_params) {
-    if (reconfig_params == nullptr) {
+    if (reconfig_params == nullptr || reconfig_params->width == 0 || reconfig_params->height == 0 ||
+        reconfig_params->num_decode_surfaces < 1 || reconfig_params->bit_depth_minus_8 > 2) {
         return ROCDEC_INVALID_PARAMETER;
     }
     rocDecStatus rocdec_status;

--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -332,11 +332,15 @@ rocDecStatus VaapiVideoDecoder::ReconfigureDecoder(RocdecReconfigureDecoderInfo 
         return ROCDEC_NOT_SUPPORTED;
     }
     CHECK_VAAPI(vaDestroySurfaces(va_display_, va_surface_ids_.data(), va_surface_ids_.size()));
-    CHECK_VAAPI(vaDestroyContext(va_display_, va_context_id_));
+    if (va_context_id_) {
+        CHECK_VAAPI(vaDestroyContext(va_display_, va_context_id_));
+        va_context_id_ = 0;
+    }
     // Need to re-create VA config if bit deepth changes
     bool create_va_config = decoder_create_info_.bit_depth_minus_8 != reconfig_params->bit_depth_minus_8 ? true : false;
     if (create_va_config) {
         CHECK_VAAPI(vaDestroyConfig(va_display_, va_config_id_));
+        va_config_id_ = 0;
     }
 
     va_surface_ids_.clear();


### PR DESCRIPTION
This PR addresses a bug related to decoder reconfiguration when uninitialized reconfiguration parameters are passed.