### PR TITLE
close the drm_fd in the VaContext destructor

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -23,14 +23,11 @@ THE SOFTWARE.
 #include "vaapi_videodecoder.h"
 
 VaapiVideoDecoder::VaapiVideoDecoder(RocDecoderCreateInfo &decoder_create_info) : decoder_create_info_{decoder_create_info},
-    drm_fd_{-1}, va_display_{0}, va_config_attrib_{{}}, va_config_id_{0}, va_profile_ {VAProfileNone}, va_context_id_{0}, va_surface_ids_{{}},
+    va_display_{0}, va_config_attrib_{{}}, va_config_id_{0}, va_profile_ {VAProfileNone}, va_context_id_{0}, va_surface_ids_{{}},
     supports_modifiers_{false}, pic_params_buf_id_{0}, iq_matrix_buf_id_{0}, num_slices_{0}, slice_data_buf_id_{0} {
 };
 
 VaapiVideoDecoder::~VaapiVideoDecoder() {
-    if (drm_fd_ != -1) {
-        close(drm_fd_);
-    }
     if (va_display_) {
         rocDecStatus rocdec_status = ROCDEC_SUCCESS;
         rocdec_status = DestroyDataBuffers();
@@ -517,6 +514,9 @@ VaContext::VaContext() {
 
 VaContext::~VaContext() {
     for (int i = 0; i < va_contexts_.size(); i++) {
+        if (va_contexts_[i].drm_fd != -1) {
+            close(va_contexts_[i].drm_fd);
+        }
         if (va_contexts_[i].va_display) {
             if (vaTerminate(va_contexts_[i].va_display) != VA_STATUS_SUCCESS) {
                 ERR("Failed to termiate VA");

--- a/src/rocdecode/vaapi/vaapi_videodecoder.h
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.h
@@ -101,7 +101,6 @@ public:
 
 private:
     RocDecoderCreateInfo decoder_create_info_;
-    int drm_fd_;
     VADisplay va_display_;
     VAConfigAttrib va_config_attrib_;
     VAConfigID va_config_id_;


### PR DESCRIPTION
This PR explicitly closes the `drm_fd` (the file descriptor for the DRM connection) for the `VaContext `class and removes the unused `drm_fd_` variable from the `VaapiVideoDecoder` class. 