### PR TITLE
AV1 decode resilience: Do not throw exceptions on picture decode or decoder reconfig errors.

### DIFF
--- a/src/parser/av1_parser.cpp
+++ b/src/parser/av1_parser.cpp
@@ -59,7 +59,7 @@ rocDecStatus Av1VideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
             ERR("Error occurred in picture data parsing.");
-            return ROCDEC_SUCCESS;
+            return ROCDEC_RUNTIME_ERROR;
         }
     } else if (!(p_data->flags & ROCDEC_PKT_ENDOFSTREAM)) {
         // If no payload and EOS is not set, treated as invalid.

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -614,7 +614,9 @@ int RocVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
         return 0;
     }
     if (p_video_format->reconfig_options == ROCDEC_RECONFIG_NEW_SURFACES) {
-        ROCDEC_API_CALL(rocDecReconfigureDecoder(roc_decoder_, &reconfig_params));
+         if (rocDecReconfigureDecoder(roc_decoder_, &reconfig_params) != ROCDEC_SUCCESS) {
+            return 0;
+         }
     }
 
     input_video_info_str_.str("");
@@ -860,7 +862,9 @@ int RocVideoDecoder::DecodeFrame(const uint8_t *data, size_t size, int pkt_flags
     if (!data || size == 0) {
         packet.flags |= ROCDEC_PKT_ENDOFSTREAM;
     }
-    ROCDEC_API_CALL(rocDecParseVideoData(rocdec_parser_, &packet));
+    if (rocDecParseVideoData(rocdec_parser_, &packet) != ROCDEC_SUCCESS) {
+        ROCDEC_ERR("Error occurred in rocDecParseVideoData().");
+    }
     if (num_decoded_pics) {
         *num_decoded_pics = decoded_pic_cnt_;
     }


### PR DESCRIPTION
 - This PR allows the decoder to be able to handle more AV1 error streams.