### PR TITLE
AV1 error resilience: Added tile size error detection and handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 
 * GetStream() interface call from RocVideoDecoder utility class
 
+### Changed
+
+* Changed asserts in RocVideoDecoder utility class query API calls to error checks.
+
 ## rocDecode 0.10.0 for ROCm 6.4
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 
 ### Changed
 
-* Changed asserts in query API calls in RocVideoDecoder utility class to error checks.
+* Changed asserts in query API calls in RocVideoDecoder utility class to error reports, to avoid hard stop during query in case error occurs and to let the caller decide actions.
 
 ## rocDecode 0.10.0 for ROCm 6.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 
 ### Changed
 
-* Changed asserts in RocVideoDecoder utility class query API calls to error checks.
+* Changed asserts in query API calls in RocVideoDecoder utility class to error checks.
 
 ## rocDecode 0.10.0 for ROCm 6.4
 

--- a/src/parser/av1_parser.cpp
+++ b/src/parser/av1_parser.cpp
@@ -119,7 +119,10 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                 obu_byte_offset_ += bytes_parsed;
                 if (obu_size_ > bytes_parsed) {
                     obu_size_ -= bytes_parsed;
-                    ParseTileGroupObu(pic_data_buffer_ptr_ + obu_byte_offset_, obu_size_);
+                    if (ParseTileGroupObu(pic_data_buffer_ptr_ + obu_byte_offset_, obu_size_) != PARSER_OK) {
+                        ERR("Error occurred in ParseTileGroupObu(). Skip this OBU.");
+                        break;
+                    }
                 } else {
                     ERR("Frame OBU size error.");
                     return PARSER_OUT_OF_RANGE;
@@ -127,7 +130,9 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                 break;
             }
             case kObuTileGroup: {
-                ParseTileGroupObu(pic_data_buffer_ptr_ + obu_byte_offset_, obu_size_);
+                if (ParseTileGroupObu(pic_data_buffer_ptr_ + obu_byte_offset_, obu_size_) != PARSER_OK) {
+                    ERR("Error occurred in ParseTileGroupObu(). Skip this OBU.");
+                }
                 break;
             }
             default:
@@ -1230,7 +1235,7 @@ ParserResult Av1VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
     return PARSER_OK;
 }
 
-void Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
+ParserResult Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
     size_t offset = 0;  // current bit offset
     Av1FrameHeader *p_frame_header = &frame_header_;
     Av1TileGroupDataInfo *p_tile_group = &tile_group_data_;
@@ -1272,6 +1277,7 @@ void Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
         } else {
             uint32_t tile_size_bytes = p_frame_header->tile_info.tile_size_bytes_minus_1 + 1;
             uint32_t tile_size = ReadLeBytes(p_tg_buf, tile_size_bytes) + 1;
+            CHECK_ALLOWED_MAX("Tile size", tile_size, tg_size);
             p_tile_group->tile_data_info[tile_num].tile_size = tile_size;
             p_tile_group->tile_data_info[tile_num].tile_offset = p_tg_buf + tile_size_bytes - p_tile_group->buffer_ptr;
             tg_size -= tile_size + tile_size_bytes;
@@ -1290,6 +1296,7 @@ void Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
         }
         seen_frame_header_ = 0;
     }
+    return PARSER_OK;
 }
 
 void Av1VideoParser::ParseColorConfig(const uint8_t *p_stream, size_t &offset, Av1SequenceHeader *p_seq_header) {

--- a/src/parser/av1_parser.h
+++ b/src/parser/av1_parser.h
@@ -226,9 +226,9 @@ protected:
     /*! \brief Function to parse a tile group OBU
      * \param [in] p_stream Pointer to the bit stream
      * \param [in] size Byte size of the stream
-     * \return None
+     * \return <tt>ParserResult</tt>
      */
-    void ParseTileGroupObu(uint8_t *p_stream, size_t size);
+    ParserResult ParseTileGroupObu(uint8_t *p_stream, size_t size);
 
     /*! \brief Function to parse color config in sequence header
      * \param [in] p_stream Pointer to the bit stream


### PR DESCRIPTION
This PR improves error resilience during AV1 tile group parsing by changing the function signature to return a ParserResult and adding error checks for tile size detection.

 - Modified ParseTileGroupObu signature and updated its implementation accordingly.
 - Added error checking and logging in ParsePictureData to skip OBUs upon tile group parse errors.
 - Also added additional update to change log for PR#574.