### PR TITLE
VideoDecodeRGB sample - Fix CMake configuration warning

### DIFF
--- a/samples/videoDecodeRGB/CMakeLists.txt
+++ b/samples/videoDecodeRGB/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(videodecodergb)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocDecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")


### PR DESCRIPTION
This PR addresses the following warning:

```
CMake Deprecation Warning at /opt/rocm-6.5.0/share/rocm/cmake/ROCMConfig.cmake:12 (message):
  Use of find_package(ROCM) is deprecated as of ROCm 6.4.  Please use
  find_package(ROCmCMakeBuildTools)
Call Stack (most recent call first):

```