### PR TITLE
CMake - Add support for explicitly linking libdrm_amdgpu with rocdecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for rocDecode is available at [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
-## rocDecode 0.13.1 (unreleased)
+## rocDecode 0.13.2 (unreleased)
 
 ### Added
 
@@ -31,6 +31,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 ### Changed
 
 * Changed asserts in query API calls in RocVideoDecoder utility class to error reports, to avoid hard stop during query in case error occurs and to let the caller decide actions.
+* `libdrm_amdgpu` is now explicitly linked with rocdecode.
 
 ## rocDecode 0.10.0 for ROCm 6.4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif()
 
 # rocDecode Version
-set(VERSION "0.13.1")
+set(VERSION "0.13.2")
 
 # Set Project Version and Language
 project(rocdecode VERSION ${VERSION} LANGUAGES CXX)
@@ -105,6 +105,7 @@ option(ROCDECODE_ENABLE_ROCPROFILER_REGISTER "Enable rocprofiler-register suppor
 
 find_package(HIP QUIET)
 find_package(Libva QUIET)
+find_package(Libdrm_amdgpu QUIET)
 
 if(ROCDECODE_ENABLE_ROCPROFILER_REGISTER)
   find_package(rocprofiler-register QUIET
@@ -112,7 +113,7 @@ if(ROCDECODE_ENABLE_ROCPROFILER_REGISTER)
     PATHS ${ROCM_PATH})
 endif()
 
-if(HIP_FOUND AND Libva_FOUND)
+if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
 
   # HIP
   set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
@@ -120,6 +121,10 @@ if(HIP_FOUND AND Libva_FOUND)
   include_directories(${LIBVA_INCLUDE_DIR})
   set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${LIBVA_LIBRARY})
   set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${LIBVA_DRM_LIBRARY})
+
+  # DRM_AMDGPU
+  include_directories(${LIBDRM_AMDGPU_INCLUDE_DIR})
+  set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${LIBDRM_AMDGPU_LIBRARY})
 
   # rocprofiler
   if (rocprofiler-register_FOUND)
@@ -132,13 +137,6 @@ if(HIP_FOUND AND Libva_FOUND)
   file(GLOB_RECURSE SOURCES "./src/*.cpp")
   # rocdecode.so
   add_library(${PROJECT_NAME} SHARED ${SOURCES})
-
-  # DRM
-  find_path(AMDGPU_DRM_INCLUDE_DIRS libdrm/amdgpu.h
-    PATHS /opt/amdgpu/include /usr/include /usr/ /usr/local/include
-    NO_DEFAULT_PATH
-  )
-  target_include_directories(${PROJECT_NAME} PRIVATE ${AMDGPU_DRM_INCLUDE_DIRS})
 
   # --all-warnings/-Wall       -- Enable most warning messages
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
@@ -422,4 +420,7 @@ else()
   if(NOT Libva_FOUND)
     message(FATAL_ERROR "-- ERROR!: libva Not Found - please install libva-amdgpu-dev/libva-amdgpu-devel!")
   endif()
-endif()
+  if(NOT Libdrm_amdgpu_FOUND)
+    message(FATAL_ERROR "-- ERROR!: libdrm_amdgpu Not Found - please install libdrm-amdgpu-dev(DEBIAN)/libdrm-amdgpu-devel(RPM) package!")
+  endif()
+  endif()

--- a/cmake/FindLibdrm_amdgpu.cmake
+++ b/cmake/FindLibdrm_amdgpu.cmake
@@ -1,0 +1,42 @@
+################################################################################
+# Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+find_library(LIBDRM_AMDGPU_LIBRARY NAMES drm_amdgpu HINTS /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
+find_path(LIBDRM_AMDGPU_INCLUDE_DIR NAMES libdrm/amdgpu.h libdrm/amdgpu_drm.h PATHS /opt/amdgpu/include /usr/include /usr/ /usr/local/include NO_DEFAULT_PATH)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libdrm_amdgpu DEFAULT_MSG LIBDRM_AMDGPU_INCLUDE_DIR LIBDRM_AMDGPU_LIBRARY)
+mark_as_advanced(LIBDRM_AMDGPU_INCLUDE_DIR LIBDRM_AMDGPU_LIBRARY)
+
+if(Libdrm_amdgpu_FOUND)
+  if(NOT TARGET Libdrm_amdgpu::drm_amdgpu)
+    add_library(Libdrm_amdgpu::drm_amdgpu UNKNOWN IMPORTED)
+    set_target_properties(Libdrm_amdgpu::drm_amdgpu PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBDRM_AMDGPU_INCLUDE_DIR}"
+      IMPORTED_LOCATION "${LIBDRM_AMDGPU_LIBRARY}")
+  endif()
+  message("-- ${White}Using Libdrm_amdgpu -- \n\tLibraries:${LIBDRM_AMDGPU_LIBRARY} \n\tIncludes:${LIBDRM_AMDGPU_INCLUDE_DIR} ${ColourReset}")
+else()
+  if(Libdrm_amdgpu_FIND_REQUIRED)
+    message(FATAL_ERROR "{Red}FindLibdrm_amdgpu -- Libdrm_admgpu NOT FOUND${ColourReset}")
+  endif()
+endif()


### PR DESCRIPTION
We utilize several APIs from libdrm_amdgpu, including `amdgpu_query_hw_ip_count`. Previously, we did not explicitly link libdrm_amdgpu with rocdecode; instead, this linking occurred implicitly through the dependencies of libva-drm. This PR explicitly links libdrm_amdgpu to avoid potential dependency issues on certain operating systems.