### PR TITLE
* FFMPEG SW decode: Replaced the assert against 0 display width with an error check, to avoid abortion in a query call.

### DIFF
--- a/utils/ffmpegvideodecode/ffmpeg_video_dec.h
+++ b/utils/ffmpegvideodecode/ffmpeg_video_dec.h
@@ -120,7 +120,7 @@ class FFMpegVideoDecoder: public RocVideoDecoder {
         /**
         *   @brief  This function is used to get the current frame size based on pixel format.
         */
-        virtual int GetFrameSize() { assert(disp_width_); return ((disp_width_ * disp_height_) + ((chroma_height_ * chroma_width_) * num_chroma_planes_)) * byte_per_pixel_; }
+        virtual int GetFrameSize() {CHECK_ZERO("Display width", disp_width_); return disp_width_ * (disp_height_ + (chroma_height_ * num_chroma_planes_)) * byte_per_pixel_; }
 
     private:
         /**

--- a/utils/ffmpegvideodecode/ffmpeg_video_dec.h
+++ b/utils/ffmpegvideodecode/ffmpeg_video_dec.h
@@ -120,7 +120,7 @@ class FFMpegVideoDecoder: public RocVideoDecoder {
         /**
         *   @brief  This function is used to get the current frame size based on pixel format.
         */
-        virtual int GetFrameSize() {CHECK_ZERO("Display width", disp_width_); return disp_width_ * (disp_height_ + (chroma_height_ * num_chroma_planes_)) * byte_per_pixel_; }
+        virtual int GetFrameSize() {CHECK_ZERO("Display width", disp_width_); return ((disp_width_ * disp_height_) + ((chroma_height_ * chroma_width_) * num_chroma_planes_)) * byte_per_pixel_; }
 
     private:
         /**


### PR DESCRIPTION
- This PR adds more graceful error handling on 0 display width value in GetFrameSize() query call.