### PR TITLE
Remove the call to vaQuerySurfaceStatus before vaSyncSurface

### DIFF
--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -312,11 +312,7 @@ rocDecStatus VaapiVideoDecoder::SyncSurface(int pic_idx) {
     if (pic_idx >= va_surface_ids_.size()) {
         return ROCDEC_INVALID_PARAMETER;
     }
-    VASurfaceStatus surface_status;
-    CHECK_VAAPI(vaQuerySurfaceStatus(va_display_, va_surface_ids_[pic_idx], &surface_status));
-    if (surface_status != VASurfaceReady) {
-        CHECK_VAAPI(vaSyncSurface(va_display_, va_surface_ids_[pic_idx]));
-    }
+    CHECK_VAAPI(vaSyncSurface(va_display_, va_surface_ids_[pic_idx]));
     return ROCDEC_SUCCESS;
 }
 


### PR DESCRIPTION
We currently call `vaQuerySurfaceStatus`, and if the status is not `VASurfaceReady`, we call `vaSyncSurface`. Ultimately, we always end up calling `vaSyncSurface` to wait for decode completion, as the surface status is not `VASurfaceReady `, making the vaQuerySurfaceStatus call unnecessary.