### PR TITLE
Utils - Remove the call to rocDecGetDecodeStatus after rocDecGetVideoFrame

### DIFF
--- a/api/rocdecode/rocdecode.h
+++ b/api/rocdecode/rocdecode.h
@@ -1717,9 +1717,10 @@ extern rocDecStatus ROCDECAPI rocDecDecodeFrame(rocDecDecoderHandle decoder_hand
 /************************************************************************************************************/
 //! \fn rocDecStatus ROCDECAPI rocDecGetDecodeStatus(rocDecDecoderHandle decoder_handle, int pic_idx, RocdecDecodeStatus* decode_status);
 //! \ingroup group_amd_rocdecode
-//! Get the decode status for frame corresponding to nPicIdx
-//! API is currently supported for HEVC, AVC/H264 and JPEG codecs.
-//! API returns ROCDEC_NOT_SUPPORTED error code for unsupported GPU or codec.
+//! Get the decode status for frame corresponding to nPicIdx.
+//! Please note that this API makes a non-blocking call and returns the status of the frame associated with nPicIdx at the time of the call,
+//! without waiting for the decoding to complete. The decode_status->decode_status can be either rocDecodeStatus_Success, indicating that
+//! the decoding has been completed, or rocDecodeStatus_InProgress, which means that the decoding is still in progress.
 /************************************************************************************************************/
 extern rocDecStatus ROCDECAPI rocDecGetDecodeStatus(rocDecDecoderHandle decoder_handle, int pic_idx, RocdecDecodeStatus *decode_status);
 
@@ -1739,6 +1740,8 @@ extern rocDecStatus ROCDECAPI rocDecReconfigureDecoder(rocDecDecoderHandle decod
 //! Post-process and map video frame corresponding to pic_idx for use in HIP. Returns HIP device pointer and associated
 //! pitch(horizontal stride) of the video frame. Returns device memory pointers and pitch for each plane (Y, U and V) seperately
 //! horizontal_pitch is a pointer to an unsigned 32-bit integer array of size 3.
+//! Please note that this API is a blocking call. If the video frame associated with the pic_idx is not ready, the call
+//! will wait for the decoding to complete before mapping the video frame for use in HIP.
 /************************************************************************************************************************/
 extern rocDecStatus ROCDECAPI rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx,
                                                     void *dev_mem_ptr[3], uint32_t *horizontal_pitch,

--- a/samples/rocdecDecode/rocdecdecode.cpp
+++ b/samples/rocdecDecode/rocdecdecode.cpp
@@ -515,14 +515,6 @@ int ROCDECAPI handle_picture_display(void* user_data, RocdecParserDispInfo* disp
     RocdecProcParams params = {};
     params.progressive_frame = disp_info->progressive_frame;
     params.top_field_first = disp_info->top_field_first;
-    // check if decoding is complete
-    RocdecDecodeStatus dec_status;
-    memset(&dec_status, 0, sizeof(dec_status));
-    CHECK(rocDecGetDecodeStatus(p_dec_info->decoder, disp_info->picture_index, &dec_status));
-    if ((dec_status.decode_status == rocDecodeStatus_Error || dec_status.decode_status == rocDecodeStatus_Error_Concealed)) {
-        std::cerr << "Decode Error occurred for picture: " << disp_info->picture_index << std::endl;
-        return 0;
-    }
     // get device memory pointer for decoded output surface
     void* dev_mem_ptr[3] = { 0 };
     uint32_t pitch[3] = { 0 };

--- a/src/rocdecode-host/avcodec/avcodec_videodecoder.h
+++ b/src/rocdecode-host/avcodec/avcodec_videodecoder.h
@@ -40,6 +40,7 @@ extern "C" {
 #include <condition_variable>
 #include <queue>
 #include <atomic>
+#include <thread>
 #include "../src/commons.h"
 #include "../api/rocdecode/rocdecode.h"
 #include "../api/rocdecode/rocdecode_host.h"

--- a/src/rocdecode/rocdecode_api.cpp
+++ b/src/rocdecode/rocdecode_api.cpp
@@ -108,8 +108,9 @@ rocDecDecodeFrame(rocDecDecoderHandle decoder_handle, RocdecPicParams *pic_param
 /************************************************************************************************************/
 //! \fn rocDecStatus ROCDECAPI RocdecGetDecodeStatus(rocDecDecoderHandle decoder_handle, int pic_idx, RocdecDecodeStatus* decode_status);
 //! Get the decode status for frame corresponding to pic_idx
-//! API is currently supported for HEVC codec.
-//! API returns ROCDEC_NOT_SUPPORTED error code for unsupported GPU or codec.
+//! Please note that this API makes a non-blocking call and returns the status of the frame associated with nPicIdx at the time of the call,
+//! without waiting for the decoding to complete. The decode_status->decode_status can be either rocDecodeStatus_Success, indicating that
+//! the decoding has been completed, or rocDecodeStatus_InProgress, which means that the decoding is still in progress.
 /************************************************************************************************************/
 rocDecStatus ROCDECAPI 
 rocDecGetDecodeStatus(rocDecDecoderHandle decoder_handle, int pic_idx, RocdecDecodeStatus* decode_status) {
@@ -156,7 +157,9 @@ rocDecReconfigureDecoder(rocDecDecoderHandle decoder_handle, RocdecReconfigureDe
 //! \fn rocDecStatus ROCDECAPI rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx, unsigned int *dev_mem_ptr,
 //!         unsigned int *horizontal_pitch, RocdecProcParams *vid_postproc_params);
 //! Post-process and map video frame corresponding to pic_idx for use in HIP. Returns HIP device pointer and associated
-//! pitch(horizontal stride) of the video frame. Returns device memory pointers for each plane (Y, U and V) seperately
+//! pitch(horizontal stride) of the video frame. Returns device memory pointers for each plane (Y, U and V) seperately.
+//! Please note that this API is a blocking call. If the video frame associated with the pic_idx is not ready, the call
+//! will wait for the decoding to complete before mapping the video frame for use in HIP.
 /************************************************************************************************************************/
 rocDecStatus ROCDECAPI 
 rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx,

--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -286,9 +286,6 @@ rocDecStatus VaapiVideoDecoder::GetDecodeStatus(int pic_idx, RocdecDecodeStatus 
         case VASurfaceReady:
             decode_status->decode_status = rocDecodeStatus_Success;
             break;
-        case VASurfaceDisplaying:
-            decode_status->decode_status = rocDecodeStatus_Displaying;
-            break;
         default:
            decode_status->decode_status = rocDecodeStatus_Invalid;
     }

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -797,12 +797,6 @@ int RocVideoDecoder::HandlePictureDisplay(RocdecParserDispInfo *pDispInfo) {
             HIP_API_CALL(hipStreamSynchronize(hip_stream_));
         }
     } else {
-        RocdecDecodeStatus dec_status;
-        memset(&dec_status, 0, sizeof(dec_status));
-        rocDecStatus result = rocDecGetDecodeStatus(roc_decoder_, pDispInfo->picture_index, &dec_status);
-        if (result == ROCDEC_SUCCESS && (dec_status.decode_status == rocDecodeStatus_Error || dec_status.decode_status == rocDecodeStatus_Error_Concealed)) {
-            std::cerr << "Decode Error occurred for picture: " << pic_num_in_dec_order_[pDispInfo->picture_index] << std::endl;
-        }
         output_frame_cnt_++;
     }
 

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -720,12 +720,6 @@ int RocVideoDecoder::HandlePictureDisplay(RocdecParserDispInfo *pDispInfo) {
         void * src_dev_ptr[3] = { 0 };
         uint32_t src_pitch[3] = { 0 };
         ROCDEC_API_CALL(rocDecGetVideoFrame(roc_decoder_, pDispInfo->picture_index, src_dev_ptr, src_pitch, &video_proc_params));
-        RocdecDecodeStatus dec_status;
-        memset(&dec_status, 0, sizeof(dec_status));
-        rocDecStatus result = rocDecGetDecodeStatus(roc_decoder_, pDispInfo->picture_index, &dec_status);
-        if (result == ROCDEC_SUCCESS && (dec_status.decode_status == rocDecodeStatus_Error || dec_status.decode_status == rocDecodeStatus_Error_Concealed)) {
-            std::cerr << "Decode Error occurred for picture: " << pic_num_in_dec_order_[pDispInfo->picture_index] << std::endl;
-        }
         if (out_mem_type_ == OUT_SURFACE_MEM_DEV_INTERNAL) {
             DecFrameBuffer dec_frame = { 0 };
             dec_frame.frame_ptr = (uint8_t *)(src_dev_ptr[0]);


### PR DESCRIPTION
We are currently calling `rocDecGetDecodeStatus` after invoking `rocDecGetVideoFrame` to check if the decode status is either `rocDecodeStatus_Error` or `rocDecodeStatus_Error_Concealed`, at which point we print an error message. 

However, this call to `rocDecGetDecodeStatus` is unnecessary for two reasons. First, `rocDecGetVideoFrame` internally calls `vaSyncSurface`, and if an error occurs during that process, we report the error and exit the function, meaning we never actually reach the `rocDecGetDecodeStatus` call. 

Second, the `rocDecGetDecodeStatus` implementation does not report `rocDecodeStatus_Error` or `rocDecodeStatus_Error_Concealed`. The only supported statuses are `rocDecodeStatus_InProgress`, `rocDecodeStatus_Success`, and `rocDecodeStatus_Displaying` (see [here](https://github.com/ROCm/rocDecode/blob/develop/src/rocdecode/vaapi/vaapi_videodecoder.cpp#L276)).



