### PR TITLE
Set video_signal_description struct to 0 by default

### DIFF
--- a/src/parser/avc_parser.cpp
+++ b/src/parser/avc_parser.cpp
@@ -398,6 +398,7 @@ ParserResult AvcVideoParser::NotifyNewSps(AvcSeqParameterSet *p_sps) {
     }
 
     video_format_params_.reconfig_options = ROCDEC_RECONFIG_NEW_SURFACES;
+    video_format_params_.video_signal_description = {0};
     if (p_sps->vui_parameters_present_flag) {
         video_format_params_.video_signal_description.video_format = p_sps->vui_seq_parameters.video_format;
         video_format_params_.video_signal_description.video_full_range_flag = p_sps->vui_seq_parameters.video_full_range_flag;

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -194,6 +194,7 @@ int HevcVideoParser::FillSeqCallbackFn(HevcSeqParamSet* sps_data) {
     }
 
     video_format_params_.reconfig_options = ROCDEC_RECONFIG_NEW_SURFACES;
+    video_format_params_.video_signal_description = {0};
     if (sps_data->vui_parameters_present_flag) {
         video_format_params_.video_signal_description.video_format = sps_data->vui_parameters.video_format;
         video_format_params_.video_signal_description.video_full_range_flag = sps_data->vui_parameters.video_full_range_flag;


### PR DESCRIPTION
This is present in AV1 and VP9, but missed for AVC and HEVC.
Need to set this to 0 by default if no VUI is available in the stream to avoid junk values by default