### PR TITLE
Decode output dumping improvement: Better condition check for new dump file creation.

### DIFF
--- a/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
+++ b/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp
@@ -394,6 +394,7 @@ int FFMpegVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
             target_width_ = (crop_rect_.right - crop_rect_.left + 1) & ~1;
             target_height_ = (crop_rect_.bottom - crop_rect_.top + 1) & ~1;
         }
+        is_output_surface_changed_ = true;
     }
 
     surface_stride_ = target_width_ * byte_per_pixel_;
@@ -432,7 +433,6 @@ int FFMpegVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
         << "\tDisplay area : [" << p_video_format->display_area.left << ", " << p_video_format->display_area.top << ", "
             << p_video_format->display_area.right << ", " << p_video_format->display_area.bottom << "]" << std::endl;
     input_video_info_str_ << std::endl;
-    is_decoder_reconfigured_ = true;
     return 1;
 }
 
@@ -838,7 +838,7 @@ void FFMpegVideoDecoder::SaveFrameToFile(std::string output_file_name, void *sur
     }
 
     // don't overwrite to the same file if reconfigure is detected for a resolution changes.
-    if (is_decoder_reconfigured_) {
+    if (is_output_surface_changed_) {
         if (fp_out_) {
             fclose(fp_out_);
             fp_out_ = nullptr;
@@ -856,7 +856,7 @@ void FFMpegVideoDecoder::SaveFrameToFile(std::string output_file_name, void *sur
                 output_file_name += to_append;
             }
         }
-        is_decoder_reconfigured_ = false;
+        is_output_surface_changed_ = false;
     } 
 
     if (fp_out_ == nullptr) {

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -587,6 +587,7 @@ int RocVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
     // If the coded_width or coded_height hasn't changed but display resolution has changed, then need to update width and height for
     // correct output with cropping. There is no need to reconfigure the decoder.
     if (!is_decode_res_changed && is_display_rect_changed && !is_bit_depth_changed && !is_dec_surface_num_changed) {
+        is_output_surface_changed_ = true;
         return 1;
     }
 
@@ -642,8 +643,8 @@ int RocVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
     input_video_info_str_ << std::endl;
     std::cout << input_video_info_str_.str();
 
-    if (is_decode_res_changed || is_bit_depth_changed) {
-        is_decoder_reconfigured_ = true;
+    if (is_display_rect_changed || is_bit_depth_changed) {
+        is_output_surface_changed_ = true;
     }
     return 1;
 }
@@ -957,15 +958,15 @@ void RocVideoDecoder::SaveFrameToFile(std::string output_file_name, void *surf_m
         current_output_filename = output_file_name;
     }
 
-    // don't overwrite to the same file if reconfigure is detected for a resolution changes.
-    if (is_decoder_reconfigured_) {
+    // don't overwrite to the same file if reconfigure is detected for a resolution/bit depth changes.
+    if (is_output_surface_changed_) {
         if (fp_out_) {
             fclose(fp_out_);
             fp_out_ = nullptr;
         }
-        // Append the width and height of the new stream to the old file name to create a file name to save the new frames
-        // do this only if resolution changes within a stream (e.g., decoding a multi-resolution stream using the videoDecode app)
-        // don't append to the output_file_name if multiple output file name is provided (e.g., decoding multi-files using the videDecodeMultiFiles)
+        // Append the width and height of the new sequence to the old file name to create a file name to save the new frames
+        // Do this only if resolution/bit depth changes within a stream (e.g., decoding a multi-resolution stream using the videoDecode app)
+        // Don't append to the output_file_name if multiple output file name is provided (e.g., decoding multi-files using the videDecodeMultiFiles)
         if (!current_output_filename.compare(output_file_name)) {
             std::string::size_type const pos(output_file_name.find_last_of('.'));
             extra_output_file_count_++;
@@ -976,7 +977,7 @@ void RocVideoDecoder::SaveFrameToFile(std::string output_file_name, void *surf_m
                 output_file_name += to_append;
             }
         }
-        is_decoder_reconfigured_ = false;
+        is_output_surface_changed_ = false;
     } 
 
     if (fp_out_ == nullptr) {

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -522,7 +522,7 @@ class RocVideoDecoder {
         Rect crop_rect_ = {}; // user specified region of interest within diplayable area disp_rect_
         FILE *fp_sei_ = NULL;
         FILE *fp_out_ = NULL;
-        bool is_decoder_reconfigured_ = false;
+        bool is_output_surface_changed_ = false;
         std::string current_output_filename = "";
         uint32_t extra_output_file_count_ = 0;
         std::thread::id decoder_session_id_; // Decoder session identifier. Used to gather session level stats.


### PR DESCRIPTION
This PR improves the way that a new file is created for dumping decoded frames.
 - Coded video size change was used as one of the conditions to create a new file when dumping decode output. When a stream has coded video size change but the display size stays the same, there is no need to dump the decoded frames into a new file.
 - Now we replace the coded size check with display size check to avoid unnecessary new dump file creation.