### PR TITLE
Fixed the MD5 calculation error on some streams when both decoded output dumping and MD5 generation are on.

### DIFF
--- a/docs/how-to/using-rocDecode-video-decoder.rst
+++ b/docs/how-to/using-rocDecode-video-decoder.rst
@@ -93,9 +93,9 @@ For example, the reconfiguration structs are defined in |common|_ in the rocDeco
 .. code:: C++
 
     typedef enum ReconfigFlushMode_enum {
-        RECONFIG_FLUSH_MODE_NONE = 0,               /**<  Just flush to get the frame count */
-        RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 1,       /**<  The remaining frames will be dumped to file in this mode */
-        RECONFIG_FLUSH_MODE_CALCULATE_MD5 = 2,      /**<  Calculate the MD5 of the flushed frames */
+        RECONFIG_FLUSH_MODE_NONE = 0x0,               /**<  Just flush to get the frame count */
+        RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,       /**<  The remaining frames will be dumped to file in this mode */
+        RECONFIG_FLUSH_MODE_CALCULATE_MD5 = (0x1 << 1),      /**<  Calculate the MD5 of the flushed frames */
     } ReconfigFlushMode;
 
     typedef struct ReconfigDumpFileStruct_t {
@@ -108,10 +108,12 @@ For example, the reconfiguration structs are defined in |common|_ in the rocDeco
     reconfig_params.p_fn_reconfigure_flush = ReconfigureFlushCallback;
     reconfig_user_struct.b_dump_frames_to_file = dump_output_frames;
     reconfig_user_struct.output_file_name = output_file_path;
+    reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
     if (dump_output_frames) {
-        reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
-    } else {
-        reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
+        reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
+    }
+    if (b_generate_md5) {
+        reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_CALCULATE_MD5;
     }
     reconfig_params.p_reconfig_user_struct = &reconfig_user_struct;
     viddec.SetReconfigParams(&reconfig_params);

--- a/docs/how-to/using-rocDecode-video-decoder.rst
+++ b/docs/how-to/using-rocDecode-video-decoder.rst
@@ -93,8 +93,8 @@ For example, the reconfiguration structs are defined in |common|_ in the rocDeco
 .. code:: C++
 
     typedef enum ReconfigFlushMode_enum {
-        RECONFIG_FLUSH_MODE_NONE = 0x0,               /**<  Just flush to get the frame count */
-        RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,       /**<  The remaining frames will be dumped to file in this mode */
+        RECONFIG_FLUSH_MODE_NONE = 0x0,                      /**<  Just flush to get the frame count */
+        RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,              /**<  The remaining frames will be dumped to file in this mode */
         RECONFIG_FLUSH_MODE_CALCULATE_MD5 = (0x1 << 1),      /**<  Calculate the MD5 of the flushed frames */
     } ReconfigFlushMode;
 

--- a/docs/how-to/using-rocDecode-videodecode-sample.rst
+++ b/docs/how-to/using-rocDecode-videodecode-sample.rst
@@ -133,9 +133,9 @@ The reconfiguration structs are defined in |common|_ in the rocDecode samples. T
 .. code:: C++
 
   typedef enum ReconfigFlushMode_enum {
-    RECONFIG_FLUSH_MODE_NONE = 0,               /**<  Just flush to get the frame count */
-      RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 1,       /**<  The remaining frames will be dumped to file in this mode */
-      RECONFIG_FLUSH_MODE_CALCULATE_MD5 = 2,      /**<  Calculate the MD5 of the flushed frames */
+    RECONFIG_FLUSH_MODE_NONE = 0x0,               /**<  Just flush to get the frame count */
+    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,       /**<  The remaining frames will be dumped to file in this mode */
+    RECONFIG_FLUSH_MODE_CALCULATE_MD5 = (0x1 << 1),      /**<  Calculate the MD5 of the flushed frames */
   } ReconfigFlushMode;
 
   typedef struct ReconfigDumpFileStruct_t {
@@ -152,12 +152,12 @@ If the ``-o`` output file path argument was set, the remaining frames in the dec
   reconfig_params.p_fn_reconfigure_flush = ReconfigureFlushCallback;
   reconfig_user_struct.b_dump_frames_to_file = dump_output_frames;
   reconfig_user_struct.output_file_name = output_file_path;
+  reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
   if (dump_output_frames) {
-    reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
-  } else if (b_generate_md5) {
-    reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_CALCULATE_MD5;
-  } else {
-    reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
+      reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
+  }
+  if (b_generate_md5) {
+      reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_CALCULATE_MD5;
   }
   reconfig_params.p_reconfig_user_struct = &reconfig_user_struct;
 

--- a/docs/how-to/using-rocDecode-videodecode-sample.rst
+++ b/docs/how-to/using-rocDecode-videodecode-sample.rst
@@ -133,8 +133,8 @@ The reconfiguration structs are defined in |common|_ in the rocDecode samples. T
 .. code:: C++
 
   typedef enum ReconfigFlushMode_enum {
-    RECONFIG_FLUSH_MODE_NONE = 0x0,               /**<  Just flush to get the frame count */
-    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,       /**<  The remaining frames will be dumped to file in this mode */
+    RECONFIG_FLUSH_MODE_NONE = 0x0,                      /**<  Just flush to get the frame count */
+    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,              /**<  The remaining frames will be dumped to file in this mode */
     RECONFIG_FLUSH_MODE_CALCULATE_MD5 = (0x1 << 1),      /**<  Calculate the MD5 of the flushed frames */
   } ReconfigFlushMode;
 

--- a/samples/common.h
+++ b/samples/common.h
@@ -26,12 +26,12 @@ THE SOFTWARE.
 #include "md5.h"
 
 typedef enum ReconfigFlushMode_enum {
-    RECONFIG_FLUSH_MODE_NONE = 0,               /**<  Just flush to get the frame count */
-    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 1,       /**<  The remaining frames will be dumped to file in this mode */
-    RECONFIG_FLUSH_MODE_CALCULATE_MD5 = 2,      /**<  Calculate the MD5 of the flushed frames */
+    RECONFIG_FLUSH_MODE_NONE = 0x0,               /**<  Just flush to get the frame count */
+    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,       /**<  The remaining frames will be dumped to file in this mode */
+    RECONFIG_FLUSH_MODE_CALCULATE_MD5 = (0x1 << 1),      /**<  Calculate the MD5 of the flushed frames */
 } ReconfigFlushMode;
 
-// this struct is used by videodecode and videodecodeMultiFiles to dump last frames to file
+// This struct is used by sample apps to dump last frames to file
 typedef struct ReconfigDumpFileStruct_t {
     bool b_dump_frames_to_file;
     std::string output_file_name;
@@ -56,11 +56,12 @@ int ReconfigureFlushCallback(void *p_viddec_obj, uint32_t flush_mode, void *p_us
     while ((pframe = viddec->GetFrame(&pts))) {
         if (flush_mode != RECONFIG_FLUSH_MODE_NONE) {
             ReconfigDumpFileStruct *p_dump_file_struct = static_cast<ReconfigDumpFileStruct *>(p_user_struct);
-            if (flush_mode == ReconfigFlushMode::RECONFIG_FLUSH_MODE_DUMP_TO_FILE) {
+            if (flush_mode & ReconfigFlushMode::RECONFIG_FLUSH_MODE_DUMP_TO_FILE) {
                 if (p_dump_file_struct->b_dump_frames_to_file) {
                     viddec->SaveFrameToFile(p_dump_file_struct->output_file_name, pframe, surf_info);
                 }
-            } else if (flush_mode == ReconfigFlushMode::RECONFIG_FLUSH_MODE_CALCULATE_MD5) {
+            }
+            if (flush_mode & ReconfigFlushMode::RECONFIG_FLUSH_MODE_CALCULATE_MD5) {
                 MD5Generator *md5_generator = static_cast<MD5Generator*>(p_dump_file_struct->md5_generator_handle);
                 md5_generator->UpdateMd5ForFrame(pframe, surf_info);
             }

--- a/samples/common.h
+++ b/samples/common.h
@@ -26,8 +26,8 @@ THE SOFTWARE.
 #include "md5.h"
 
 typedef enum ReconfigFlushMode_enum {
-    RECONFIG_FLUSH_MODE_NONE = 0x0,               /**<  Just flush to get the frame count */
-    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,       /**<  The remaining frames will be dumped to file in this mode */
+    RECONFIG_FLUSH_MODE_NONE = 0x0,                      /**<  Just flush to get the frame count */
+    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,              /**<  The remaining frames will be dumped to file in this mode */
     RECONFIG_FLUSH_MODE_CALCULATE_MD5 = (0x1 << 1),      /**<  Calculate the MD5 of the flushed frames */
 } ReconfigFlushMode;
 

--- a/samples/videoDecode/videodecode.cpp
+++ b/samples/videoDecode/videodecode.cpp
@@ -294,12 +294,12 @@ int main(int argc, char **argv) {
         reconfig_params.p_fn_reconfigure_flush = ReconfigureFlushCallback;
         reconfig_user_struct.b_dump_frames_to_file = dump_output_frames;
         reconfig_user_struct.output_file_name = output_file_path;
+        reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
         if (dump_output_frames) {
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
-        } else if (b_generate_md5) {
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_CALCULATE_MD5;
-        } else {
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
+            reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
+        }
+        if (b_generate_md5) {
+            reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_CALCULATE_MD5;
         }
         reconfig_params.p_reconfig_user_struct = &reconfig_user_struct;
 

--- a/samples/videoDecodeBatch/videodecodebatch.cpp
+++ b/samples/videoDecodeBatch/videodecodebatch.cpp
@@ -317,10 +317,10 @@ int main(int argc, char **argv) {
         reconfig_params.p_fn_reconfigure_flush = ReconfigureFlushCallback;
         if (!b_dump_output_frames) {
             reconfig_user_struct.b_dump_frames_to_file = false;
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
+            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
         } else {
             reconfig_user_struct.b_dump_frames_to_file = true;
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
+            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
         }
         reconfig_params.p_reconfig_user_struct = &reconfig_user_struct;
 

--- a/samples/videoDecodePicFiles/videodecodepicfiles.cpp
+++ b/samples/videoDecodePicFiles/videodecodepicfiles.cpp
@@ -265,12 +265,12 @@ int main(int argc, char **argv) {
         reconfig_params.p_fn_reconfigure_flush = ReconfigureFlushCallback;
         reconfig_user_struct.b_dump_frames_to_file = dump_output_frames;
         reconfig_user_struct.output_file_name = output_file_path;
+        reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
         if (dump_output_frames) {
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
-        } else if (b_generate_md5) {
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_CALCULATE_MD5;
-        } else {
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
+            reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
+        }
+        if (b_generate_md5) {
+            reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_CALCULATE_MD5;
         }
         reconfig_params.p_reconfig_user_struct = &reconfig_user_struct;
 

--- a/samples/videoDecodeRaw/videodecoderaw.cpp
+++ b/samples/videoDecodeRaw/videodecoderaw.cpp
@@ -41,9 +41,9 @@ THE SOFTWARE.
 #include "roc_video_dec.h"
 
 typedef enum ReconfigFlushMode_enum {
-    RECONFIG_FLUSH_MODE_NONE = 0,               /**<  Just flush to get the frame count */
-    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 1,       /**<  The remaining frames will be dumped to file in this mode */
-    RECONFIG_FLUSH_MODE_CALCULATE_MD5 = 2,      /**<  Calculate the MD5 of the flushed frames */
+    RECONFIG_FLUSH_MODE_NONE = 0x0,               /**<  Just flush to get the frame count */
+    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,       /**<  The remaining frames will be dumped to file in this mode */
+    RECONFIG_FLUSH_MODE_CALCULATE_MD5 = (0x1 << 1),      /**<  Calculate the MD5 of the flushed frames */
 } ReconfigFlushMode;
 
 // this struct is used by videodecode and videodecodeMultiFiles to dump last frames to file
@@ -71,7 +71,7 @@ int ReconfigureFlushCallback(void *p_viddec_obj, uint32_t flush_mode, void *p_us
     while ((pframe = viddec->GetFrame(&pts))) {
         if (flush_mode != RECONFIG_FLUSH_MODE_NONE) {
             ReconfigDumpFileStruct *p_dump_file_struct = static_cast<ReconfigDumpFileStruct *>(p_user_struct);
-            if (flush_mode == ReconfigFlushMode::RECONFIG_FLUSH_MODE_DUMP_TO_FILE) {
+            if (flush_mode & ReconfigFlushMode::RECONFIG_FLUSH_MODE_DUMP_TO_FILE) {
                 if (p_dump_file_struct->b_dump_frames_to_file) {
                     viddec->SaveFrameToFile(p_dump_file_struct->output_file_name, pframe, surf_info);
                 }
@@ -252,7 +252,7 @@ int main(int argc, char **argv) {
         reconfig_user_struct.b_dump_frames_to_file = dump_output_frames;
         reconfig_user_struct.output_file_name = output_file_path;
         if (dump_output_frames) {
-            reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
+            reconfig_params.reconfig_flush_mode |= RECONFIG_FLUSH_MODE_DUMP_TO_FILE;
         } else {
             reconfig_params.reconfig_flush_mode = RECONFIG_FLUSH_MODE_NONE;
         }

--- a/samples/videoDecodeRaw/videodecoderaw.cpp
+++ b/samples/videoDecodeRaw/videodecoderaw.cpp
@@ -41,8 +41,8 @@ THE SOFTWARE.
 #include "roc_video_dec.h"
 
 typedef enum ReconfigFlushMode_enum {
-    RECONFIG_FLUSH_MODE_NONE = 0x0,               /**<  Just flush to get the frame count */
-    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,       /**<  The remaining frames will be dumped to file in this mode */
+    RECONFIG_FLUSH_MODE_NONE = 0x0,                      /**<  Just flush to get the frame count */
+    RECONFIG_FLUSH_MODE_DUMP_TO_FILE = 0x1,              /**<  The remaining frames will be dumped to file in this mode */
     RECONFIG_FLUSH_MODE_CALCULATE_MD5 = (0x1 << 1),      /**<  Calculate the MD5 of the flushed frames */
 } ReconfigFlushMode;
 


### PR DESCRIPTION
This PR fixes an MD5 calculation error by correctly handling the final flushing of frames when both output dumping and MD5 generation are enabled. Key changes include updating the ReconfigFlushMode enum to use bit flags, modifying flag checks in the flush callback to use bitwise operators, and updating various sample apps and docs to combine flags instead of overriding them.