### PR TITLE
removing link to gpu installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ access the video decoding features available on your GPU.
 > [!IMPORTANT] 
 > * `gfx908` or higher GPU required
 
-* Install ROCm `6.3.0` or later with [amdgpu-install](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/amdgpu-install.html): **Required** usecase:`rocm`
+* Install ROCm `6.3.0` or later with `amdgpu-install` and usecase:`rocm`
 > [!IMPORTANT]
 > `sudo amdgpu-install --usecase=rocm`
 
@@ -101,7 +101,11 @@ The installation process uses the following steps:
 
 * [ROCm-supported hardware](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html) install verification
 
-* Install ROCm `6.3.0` or later with [amdgpu-install](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/amdgpu-install.html) with `--usecase=rocm`
+* Install ROCm `6.3.0` or later with `amdgpu-install` and `--usecase=rocm`:
+
+  ```
+  sudo amdgpu-install --usecase=rocm
+  ```
 
 >[!IMPORTANT]
 > Use **either** [package install](#package-install) **or** [source install](#source-install) as described below.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ The rocDecode public repository is located at `https://github.com/ROCm/rocDecode
 
   .. grid-item-card:: Install
 
+    * :doc:`rocDecode prerequisites <./install/rocDecode-prerequisites>`
     * :doc:`Installing rocDecode with the package installer <./install/rocDecode-package-install>`
     * :doc:`Building and installing rocDecode from source code <./install/rocDecode-build-and-install>`
     * `rocDecode Docker containers <https://github.com/ROCm/rocDecode/tree/develop/docker>`_

--- a/docs/install/rocDecode-prerequisites.rst
+++ b/docs/install/rocDecode-prerequisites.rst
@@ -8,7 +8,7 @@ rocDecode prerequisites
 
 rocDecode requires ROCm 6.1 or later running on `accelerators based on the CDNA architecture <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html>`_.
 
-ROCm must be installed using the [AMDGPU installer](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/amdgpu-install.html) with the ``rocm`` usecase:
+ROCm must be installed using the AMDGPU installer with the ``rocm`` usecase:
 
 .. code:: shell
 


### PR DESCRIPTION
because the amdgpu installer is legacy, I'm leaving the instructions but removing the link. If this changes later, I'll change the instructions suitably.