### PR TITLE
AV1: Added 12-bit AV1 decode support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 
 ### Added
 
-* AV1 12-bit decode support on VA-API 1.23.0 and up.
+* AV1 12-bit decode support on VA-API version 1.23.0 and later.
 
 ## rocdecode 1.1.0 for ROCm 7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for rocDecode is available at [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
+## rocDecode 1.2.0 (unreleased)
+
+### Added
+
+* AV1 12-bit decode support on VA-API 1.23.0 and up.
+
 ## rocdecode 1.1.0 for ROCm 7.0.0
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif()
 
 # rocdecode Version
-set(VERSION "1.1.0")
+set(VERSION "1.2.0")
 
 # Set Project Version and Language
 project(rocdecode VERSION ${VERSION} LANGUAGES CXX)

--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -395,7 +395,14 @@ rocDecStatus VaapiVideoDecoder::CreateDecoderConfig() {
             }
             break;
         case rocDecVideoCodec_AV1:
-            va_profile_ = VAProfileAV1Profile0;
+#if VA_CHECK_VERSION(1, 23, 0)
+            if (decoder_create_info_.bit_depth_minus_8 == 4) {
+                va_profile_ = VAProfileAV1Profile2;
+            } else
+#endif
+            {
+                va_profile_ = VAProfileAV1Profile0;
+            }
             break;
         default:
             ERR("The codec type is not supported.");
@@ -649,7 +656,14 @@ rocDecStatus VaContext::CheckDecCapForCodecType(RocdecDecodeCaps *dec_cap) {
             break;
         }
         case rocDecVideoCodec_AV1: {
-            va_profile = VAProfileAV1Profile0;
+#if VA_CHECK_VERSION(1, 23, 0)
+            if (dec_cap->bit_depth_minus_8 == 4) {
+                va_profile = VAProfileAV1Profile2;
+            } else
+#endif
+            {
+                va_profile = VAProfileAV1Profile0;
+            }
             break;
         }
         default: {

--- a/utils/md5.h
+++ b/utils/md5.h
@@ -131,11 +131,11 @@ public:
         }
 
         int img_size = img_width * surf_info->bytes_per_pixel * (img_height + surf_info->chroma_height);
-        // For 10 bit, convert from P010 to LSB to match reference decoder output
+        // For 10/12 bit, convert from P010/P012 to LSB to match reference decoder output
         if (surf_info->bytes_per_pixel == 2) {
             uint16_t *ptr = reinterpret_cast<uint16_t *> (stacked_ptr);
             for (i = 0; i < img_size / 2; i++) {
-                ptr[i] = ptr[i] >> 6;
+                ptr[i] = ptr[i] >> (16 - surf_info->bit_depth);
             }
         }
 


### PR DESCRIPTION
## Motivation

This PR adds 12-bit AV1 stream decode on supported HW decoders.

## Technical Details

- 12-bit AV1 decode support is enabled upon successful decoder capability check and with VA-API version 1.23.0 and up.
- MD5 calculation on 12-bit video output is added.

## Test Plan

- Install libva with VA-API 1.23.0 and up and AMD mesa driver built with the libva.
- On supporting HW, decode 12-bit AV1 conformance stream and generate MD5 digest.
- Decode the same 12-bit AV1 conformance stream using AOM reference decoder and generate MD5 digest.
- Compare both MD5 digests.

## Test Result

- The MD5 digests form rocDeocde should match that from AOM reference decoder.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
