### PR TITLE
Fixed a regression that resulted in CI test failures.

### DIFF
--- a/samples/videoDecode/videodecode.cpp
+++ b/samples/videoDecode/videodecode.cpp
@@ -358,7 +358,7 @@ int main(int argc, char **argv) {
             n_frame_returned = viddec->DecodeFrame(pvideo, n_video_bytes, pkg_flags, pts, &decoded_pics);
 
             // get output surface info after the first decoded frame
-            if (!n_frame && (n_frame_returned > 0) && !viddec->GetOutputSurfaceInfo(&surf_info)) {
+            if (!n_frame && !viddec->GetOutputSurfaceInfo(&surf_info)) {
                 std::cerr << "Error: Failed to get Output Surface Info!" << std::endl;
                 break;
             }


### PR DESCRIPTION
## Motivation

This PR fixed a regression from previous PR#616.

## Technical Details

PR#616 resulted in CI error resilience test failures. To fix it, we need to check output surface info for every decode call to catch video size change or decode errors.

## Test Plan

To verify, run AV1 stability test on supported GPUs.

## Test Result

All streams should pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
