### PR TITLE
fixed build issues with FFMpeg AVCodec version >=59 changes

### DIFF
--- a/src/rocdecode-host/avcodec/avcodec_videodecoder.cpp
+++ b/src/rocdecode-host/avcodec/avcodec_videodecoder.cpp
@@ -387,10 +387,6 @@ rocDecStatus AvcodecVideoDecoder::NotifyNewSequence(AVFrame *p_frame) {
     p_video_format->frame_rate.denominator = dec_context_->framerate.den;
     p_video_format->bit_depth_luma_minus8 = BitDepthFromPixelFormat(dec_context_->pix_fmt) - 8;
     p_video_format->bit_depth_chroma_minus8 = p_video_format->bit_depth_luma_minus8;
-<<<<<<< Updated upstream
-    p_video_format->progressive_sequence = !p_frame->interlaced_frame;
-    p_video_format->min_num_decode_surfaces = dec_context_->delay + dec_context_->max_b_frames;
-=======
 #if USE_AVCODEC_GREATER_THAN_58_134
     p_video_format->progressive_sequence = !(p_frame->flags & AV_FRAME_FLAG_INTERLACED);
 #else
@@ -398,7 +394,6 @@ rocDecStatus AvcodecVideoDecoder::NotifyNewSequence(AVFrame *p_frame) {
 #endif
     //number of decode surfaces are internal and not exposed in avcodec based decoding. Setting some value for sanity
     p_video_format->min_num_decode_surfaces = dec_frames_.size();
->>>>>>> Stashed changes
     p_video_format->coded_width = p_frame->linesize[0];
     p_video_format->coded_height = p_frame->height;
     p_video_format->chroma_format = AVPixelFormat2rocDecVideoChromaFormat(dec_context_->pix_fmt);

--- a/src/rocdecode-host/avcodec/avcodec_videodecoder.cpp
+++ b/src/rocdecode-host/avcodec/avcodec_videodecoder.cpp
@@ -387,8 +387,18 @@ rocDecStatus AvcodecVideoDecoder::NotifyNewSequence(AVFrame *p_frame) {
     p_video_format->frame_rate.denominator = dec_context_->framerate.den;
     p_video_format->bit_depth_luma_minus8 = BitDepthFromPixelFormat(dec_context_->pix_fmt) - 8;
     p_video_format->bit_depth_chroma_minus8 = p_video_format->bit_depth_luma_minus8;
+<<<<<<< Updated upstream
     p_video_format->progressive_sequence = !p_frame->interlaced_frame;
     p_video_format->min_num_decode_surfaces = dec_context_->delay + dec_context_->max_b_frames;
+=======
+#if USE_AVCODEC_GREATER_THAN_58_134
+    p_video_format->progressive_sequence = !(p_frame->flags & AV_FRAME_FLAG_INTERLACED);
+#else
+    p_video_format->progressive_sequence = !!p_frame->interlaced_frame;;
+#endif
+    //number of decode surfaces are internal and not exposed in avcodec based decoding. Setting some value for sanity
+    p_video_format->min_num_decode_surfaces = dec_frames_.size();
+>>>>>>> Stashed changes
     p_video_format->coded_width = p_frame->linesize[0];
     p_video_format->coded_height = p_frame->height;
     p_video_format->chroma_format = AVPixelFormat2rocDecVideoChromaFormat(dec_context_->pix_fmt);

--- a/utils/video_demuxer.h
+++ b/utils/video_demuxer.h
@@ -462,7 +462,11 @@ class VideoDemuxer {
                         || !strcmp(av_fmt_input_ctx_->iformat->long_name, "Matroska / WebM"));
 
             // Check if the input file allow seek functionality.
+#if USE_AVCODEC_GREATER_THAN_58_134
+            is_seekable_ = true;    //for latest version of FFMPeg, read_seek and read_seek2 is not exposed in AVFormatContext
+#else            
             is_seekable_ = av_fmt_input_ctx_->iformat->read_seek || av_fmt_input_ctx_->iformat->read_seek2;
+#endif            
 
             if (is_h264_) {
                 const AVBitStreamFilter *bsf = av_bsf_get_by_name("h264_mp4toannexb");


### PR DESCRIPTION
Merge after #635 

## Motivation

To fix build errors in rocDecode when building with latest versions of AVCodec (Version 59 or later)

## Technical Details

Some members of AVFrame struct is deprecated and needs to be replaced with appropriate changes from newer version

## Test Plan

Make Test need to succeed all tests on UB24 system with latest version of FFMpeg library

## Test Result

Build has to pass and tests run without any failures

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
