### PR TITLE
Ctest - add host backend under ctest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -258,3 +258,17 @@ add_test(
             --test-command "videodecodergb"
             -i "${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" -resize 640x360 -of rgb
 )
+
+# 15 - videoDecode Host backend
+add_test(
+  NAME
+    video_decode-Host-Backend
+  COMMAND
+    "${CMAKE_CTEST_COMMAND}"
+            --build-and-test "${ROCM_PATH}/share/rocdecode/samples/videoDecode"
+                              "${CMAKE_CURRENT_BINARY_DIR}/videoDecode"
+            --build-generator "${CMAKE_GENERATOR}"
+            --test-command "videodecode"
+            -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
+            -backend 1
+)


### PR DESCRIPTION
Merge after #635 

## Motivation

Adds a test for testing the host backend under ctest

## Technical Details

Uses the videoDecode sample with `-backend 1`

## Test Result
```
test 15
      Start 15: video_decode-Host-Backend-HEVC

15: Test command: /usr/bin/ctest "--build-and-test" "/opt/rocm/share/rocdecode/samples/videoDecode" "/home/svcbuild/work/lk/rocDecode/build/test/videoDecode" "--build-generator" "Unix Makefiles" "--test-command" "videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" "-backend" "1"
15: Test timeout computed to be: 1500
15: Internal cmake changing into directory: /home/svcbuild/work/lk/rocDecode/build/test/videoDecode
15: ======== CMake output     ======
15: -- INFO:ROCM_PATH Set -- /opt/rocm
15: Configuring done
15: Generating done
15: Build files have been written to: /home/svcbuild/work/lk/rocDecode/build/test/videoDecode
15: ======== End CMake output ======
15: Change Dir: /home/svcbuild/work/lk/rocDecode/build/test/videoDecode
15:
15: Run Clean Command:/usr/bin/gmake -f Makefile clean
15:
15: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 25%] Building CXX object CMakeFiles/videodecode.dir/videodecode.cpp.o
15: [ 50%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
15: [ 75%] Building CXX object CMakeFiles/videodecode.dir/opt/rocm/share/rocdecode/utils/ffmpegvideodecode/ffmpeg_video_dec.cpp.o
15: [100%] Linking CXX executable videodecode
15: [100%] Built target videodecode
15:
15: Running test command: "/home/svcbuild/work/lk/rocDecode/build/test/videoDecode/videodecode" "-i" "/opt/rocm/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" "-backend" "1"
15: info: Input file: AMD_driving_virtual_20-H265.mp4
15: info: Using FFMPEG demuxer
15: info: RocDecode is using CPU backend!
15: info: Using GPU device 0 - Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
15: info: decoding started, please wait!
15: ERROR: RocVideoDecoder is not intialized
15: Error: Failed to get Output Surface Info!
15: info: Total pictures decoded: 0
15: info: Total frames output/displayed: 0
15: info: avg decoding time per picture: -nan ms
15: info: avg decode FPS: -nan
15: info: avg output/display time per frame: -nan ms
15: info: avg output/display FPS: -nan
15:
15/15 Test #15: video_decode-Host-Backend-HEVC ...   Passed    2.77 sec

100% tests passed, 0 tests failed out of 15
```

