### PR TITLE
rocdecode host - Fix build and install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 
 ### Resolved issues
 
-* Bugfix for rocdecode-host build and install
+* rocdecode-host - failure to build debuginfo packages without FFmpeg resolved.
 
 ## rocdecode 1.1.0 for ROCm 7.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 Full documentation for rocDecode is available at [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
-## rocDecode 1.3.0 (unreleased)
+## rocDecode 1.4.0 (unreleased)
 
 ### Added
 
 * AV1 12-bit decode support on VA-API version 1.23.0 and later.
+* rocdecode-host V1.0.0 library for software decode
+
+### Resolved issues
+
+* Bugfix for rocdecode-host build and install
 
 ## rocdecode 1.1.0 for ROCm 7.0.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif()
 
 # rocdecode Version
-set(VERSION "1.3.0")
+set(VERSION "1.4.0")
 
 # Set Project Version and Language
 project(rocdecode VERSION ${VERSION} LANGUAGES CXX)
@@ -59,7 +59,7 @@ find_program(DPKG_EXE dpkg)
 
 # avoid setting the default installation path to /usr/local
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "rocdecode default installation path" FORCE)
+  set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "${PROJECT_NAME} default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 set(DEFAULT_BUILD_TYPE "Release")
@@ -77,8 +77,8 @@ if(ENHANCED_MESSAGE)
   set(Cyan "${Esc}[36m")
   set(White "${Esc}[37m")
 endif()
-message("-- ${BoldBlue}rocdecode Version -- ${VERSION}${ColourReset}")
-message("-- ${BoldBlue}rocdecode Install Path -- ${CMAKE_INSTALL_PREFIX}${ColourReset}")
+message("-- ${BoldBlue}${PROJECT_NAME} Version -- ${VERSION}${ColourReset}")
+message("-- ${BoldBlue}${PROJECT_NAME} Install Path -- ${CMAKE_INSTALL_PREFIX}${ColourReset}")
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
@@ -98,13 +98,13 @@ else()
   # -fPIC     -- Generate position-independent code if possible
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
-message("-- ${BoldBlue}rocdecode Build Type -- ${CMAKE_BUILD_TYPE}${ColourReset}")
+message("-- ${BoldBlue}${PROJECT_NAME} Build Type -- ${CMAKE_BUILD_TYPE}${ColourReset}")
 
+# Developer options
 # Add an option for enabling the rocprofiler-register
 option(ROCDECODE_ENABLE_ROCPROFILER_REGISTER "Enable rocprofiler-register support" ON)
-
-#add an option for enabling FFMPEG avcodec host-based decoder
-option(ROCDECODE_ENABLE_HOST_DECODER "Enable rocdecode host-based decoder support" ON)
+# Add an option for enabling FFMPEG avcodec host-based decoder
+option(ROCDECODE_ENABLE_HOST_DECODER "Enable rocdecode-host-based decoder support" ON)
 
 find_package(HIP QUIET)
 find_package(Libva QUIET)
@@ -115,7 +115,6 @@ if(ROCDECODE_ENABLE_ROCPROFILER_REGISTER)
     HINTS $ENV{rocprofiler_register_ROOT} $ENV{ROCPROFILER_REGISTER_ROOT} ${CMAKE_INSTALL_PREFIX}
     PATHS ${ROCM_PATH})
 endif()
-
 if(ROCDECODE_ENABLE_HOST_DECODER)
   find_package(FFmpeg QUIET)
 endif()
@@ -166,7 +165,15 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
       ROCDECODE_ROCP_REG_VERSION_PATCH=${VERSION_PATCH})
   endif()
 
-  #Generate BUILD_INFO
+  # make rocdecode-host for decoding on HOST only if FFMPEG is available
+  if(ROCDECODE_ENABLE_HOST_DECODER AND FFMPEG_FOUND)
+    add_subdirectory(src/rocdecode-host)
+  else()
+    if(NOT FFMPEG_FOUND)
+      message("-- ${Yellow}${PROJECT_NAME} -- FFMPEG NOT Found; rocdecode-host exculded${ColourReset}")
+  endif()
+
+  # Generate BUILD_INFO
   configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/api/rocdecode_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/rocdecode_version.h @ONLY )
 
   # install rocdecode libs -- {ROCM_PATH}/lib
@@ -210,8 +217,8 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   install(DIRECTORY test/testScripts DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/test COMPONENT test)
   install(FILES test/rocDecodeNegativeApiTests/CMakeLists.txt test/rocDecodeNegativeApiTests/README.md test/rocDecodeNegativeApiTests/rocdecode_api_negative_tests.cpp test/rocDecodeNegativeApiTests/rocdecode_api_negative_tests.h test/rocDecodeNegativeApiTests/rocdecodenegativetest.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/test/rocDecodeNegativeApiTests COMPONENT dev)
 
-  message("-- ${White}AMD ROCm rocdecode -- CMAKE_CXX_FLAGS:${CMAKE_CXX_FLAGS}${ColourReset}")
-  message("-- ${White}AMD ROCm rocdecode -- Link Libraries: ${LINK_LIBRARY_LIST}${ColourReset}")
+  message("-- ${White}AMD ROCm ${PROJECT_NAME} -- CMAKE_CXX_FLAGS:${CMAKE_CXX_FLAGS}${ColourReset}")
+  message("-- ${White}AMD ROCm ${PROJECT_NAME} -- Link Libraries: ${LINK_LIBRARY_LIST}${ColourReset}")
 
   # Cmake module config file configurations
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/" CACHE INTERNAL "Default module path.")
@@ -264,12 +271,6 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   enable_testing()
   include(CTest)
   add_subdirectory(test)
-
-
-  # make rocdecode-host for decoding on HOST only if FFMPEG is available
-  if (ROCDECODE_ENABLE_HOST_DECODER AND FFMPEG_FOUND)
-    add_subdirectory(src/rocdecode-host)
-  endif()
 
   # set package information
   set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
@@ -399,37 +400,35 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   endif()
   if(EXISTS ${RPMBUILD_EXE})
     list(APPEND CPACK_GENERATOR "RPM")
-    message("-- ${White}rocdecode .rpm RunTime Package Requirements -- ${CPACK_RPM_RUNTIME_PACKAGE_REQUIRES}${ColourReset}")
-    message("-- ${White}rocdecode .rpm Devel Package Requirements -- ${CPACK_RPM_DEV_PACKAGE_REQUIRES}${ColourReset}")
+    message("-- ${White}${PROJECT_NAME}: .rpm RunTime Package Requirements -- ${CPACK_RPM_RUNTIME_PACKAGE_REQUIRES}${ColourReset}")
+    message("-- ${White}${PROJECT_NAME}: .rpm Devel Package Requirements -- ${CPACK_RPM_DEV_PACKAGE_REQUIRES}${ColourReset}")
   endif()
   if(EXISTS ${DPKG_EXE})
     list(APPEND CPACK_GENERATOR "DEB")
-    message("-- ${White}rocdecode .deb RunTime Package Requirements -- ${CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS}${ColourReset}")
-    message("-- ${White}rocdecode .deb Dev Package Requirements -- ${CPACK_DEBIAN_DEV_PACKAGE_DEPENDS}${ColourReset}")
+    message("-- ${White}${PROJECT_NAME}: .deb RunTime Package Requirements -- ${CPACK_DEBIAN_RUNTIME_PACKAGE_DEPENDS}${ColourReset}")
+    message("-- ${White}${PROJECT_NAME}: .deb Dev Package Requirements -- ${CPACK_DEBIAN_DEV_PACKAGE_DEPENDS}${ColourReset}")
   endif()
 
   include(CPack)
 
   cpack_add_component(runtime
                     DISPLAY_NAME "rocdecode Runtime Package"
-		    DESCRIPTION "High perf video decode SDK for AMD GPUs. Rocdecode library and license.txt")
+                    DESCRIPTION "High perf video decode SDK for AMD GPUs. Rocdecode library and license.txt")
 
   cpack_add_component(dev
                     DISPLAY_NAME "rocdecode Develop Package"
-		    DESCRIPTION "High perf video decode SDK for AMD GPUs. Rocdecode header files, and samples")
+                    DESCRIPTION "High perf video decode SDK for AMD GPUs. Rocdecode header files, and samples")
 
   cpack_add_component(asan
                     DISPLAY_NAME "rocdecode ASAN Package"
-                    DESCRIPTION "AMD rocdecode is a high performance video decode SDK for AMD GPUs. \
-rocdecode ASAN package provides rocdecode ASAN libraries")
+                    DESCRIPTION "High perf video decode SDK for AMD GPUs. rocdecode ASAN libraries")
 
   cpack_add_component(test
-                  DISPLAY_NAME "rocdecode Test Package"
-                  DESCRIPTION "AMD rocdecode is a high performance video decode SDK for AMD GPUs. \
-rocdecode Test package provides rocdecode Test Components")
+                    DISPLAY_NAME "rocdecode Test Package"
+                    DESCRIPTION "High perf video decode SDK for AMD GPUs. rocdecode test")
 
 else()
-  message("-- ${Red}AMD ROCm rocdecode -- unmet dependencies${ColourReset}")
+  message("-- ${Red}AMD ROCm ${PROJECT_NAME} -- unmet dependencies${ColourReset}")
   if(NOT HIP_FOUND)
     message(FATAL_ERROR "-- ERROR!: HIP Not Found! - please install rocm-hip-runtime-dev!")
   endif()
@@ -439,4 +438,4 @@ else()
   if(NOT Libdrm_amdgpu_FOUND)
     message(FATAL_ERROR "-- ERROR!: libdrm_amdgpu Not Found - please install libdrm-amdgpu-dev(DEBIAN)/libdrm-amdgpu-devel(RPM) package!")
   endif()
-  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   else()
     if(NOT FFMPEG_FOUND)
       message("-- ${Yellow}${PROJECT_NAME} -- FFMPEG NOT Found; rocdecode-host exculded${ColourReset}")
+    endif()
   endif()
 
   # Generate BUILD_INFO

--- a/samples/rocdecDecode/CMakeLists.txt
+++ b/samples/rocdecDecode/CMakeLists.txt
@@ -67,7 +67,7 @@ find_package(rocdecode QUIET)
 
 if(HIP_FOUND AND FFMPEG_FOUND AND rocdecode_FOUND)
     # HIP
-    find_library(rocdecode_HOST_LIBRARY rocdecodehost PATHS ${ROCM_PATH}/lib)
+    find_library(rocdecode_HOST_LIBRARY rocdecode-host PATHS ${ROCM_PATH}/lib)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
     # FFMPEG
     include_directories(${AVUTIL_INCLUDE_DIR} ${AVCODEC_INCLUDE_DIR}

--- a/samples/videoDecode/CMakeLists.txt
+++ b/samples/videoDecode/CMakeLists.txt
@@ -82,14 +82,14 @@ if(HIP_FOUND AND FFMPEG_FOUND AND rocdecode_FOUND AND Threads_FOUND AND rocprofi
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
     # rocprofiler-register
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
-    # rocdecodehost
-    find_library(ROCDECODE_HOST_LIBRARY NAMES rocdecodehost HINTS ${ROCM_PATH}/lib)
+    # rocdecode-host
+    find_library(rocdecode_HOST_LIBRARY NAMES rocdecode-host HINTS ${ROCM_PATH}/lib)
     list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecode.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ffmpeg_video_dec.cpp)
     # sample app exe
     add_executable(${PROJECT_NAME} ${SOURCES})
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocdecode::rocdecode)
-    if(ROCDECODE_HOST_LIBRARY)
-      set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${ROCDECODE_HOST_LIBRARY})
+    if(rocdecode_HOST_LIBRARY)
+      set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${rocdecode_HOST_LIBRARY})
       target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_HOST_DECODE=1)
     else()
       target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_HOST_DECODE=0)

--- a/samples/videoDecodePerf/CMakeLists.txt
+++ b/samples/videoDecodePerf/CMakeLists.txt
@@ -83,13 +83,13 @@ if(HIP_FOUND AND FFMPEG_FOUND AND rocdecode_FOUND AND Threads_FOUND AND rocprofi
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
     # rocprofiler-register
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
-    # rocdecodehost
-    find_library(ROCDECODE_HOST_LIBRARY NAMES rocdecodehost HINTS ${ROCM_PATH}/lib)
+    # rocdecode-host
+    find_library(rocdecode_HOST_LIBRARY NAMES rocdecode-host HINTS ${ROCM_PATH}/lib)
     # sample app exe
     list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodeperf.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ffmpeg_video_dec.cpp)
     add_executable(${PROJECT_NAME} ${SOURCES})
-    if(ROCDECODE_HOST_LIBRARY)
-      set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${ROCDECODE_HOST_LIBRARY})
+    if(rocdecode_HOST_LIBRARY)
+      set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${rocdecode_HOST_LIBRARY})
       target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_HOST_DECODE=1)
     else()
       target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_HOST_DECODE=0)

--- a/src/rocdecode-host/CMakeLists.txt
+++ b/src/rocdecode-host/CMakeLists.txt
@@ -82,6 +82,9 @@ if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
   endif()
   set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+  message("-- ${White}AMD ROCm ${PROJECT_NAME} -- CMAKE_CXX_FLAGS:${CMAKE_CXX_FLAGS}${ColourReset}")
+  message("-- ${White}AMD ROCm ${PROJECT_NAME} -- Link Libraries: ${LINK_LIBRARY_LIST}${ColourReset}")
+
   # install rocdecode-host libs -- {ROCM_PATH}/lib
   set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
   install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime NAMELINK_SKIP)

--- a/src/rocdecode-host/CMakeLists.txt
+++ b/src/rocdecode-host/CMakeLists.txt
@@ -30,43 +30,31 @@ elseif(ROCM_PATH)
 else()
   set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 endif()
-
+# Set AMD Clang as default compiler
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED On)
-
-# Set AMD Clang as default compiler
+set(CMAKE_CXX_EXTENSIONS ON)
 if (NOT DEFINED CMAKE_CXX_COMPILER)
   set(CMAKE_C_COMPILER ${ROCM_PATH}/bin/amdclang)
   set(CMAKE_CXX_COMPILER ${ROCM_PATH}/bin/amdclang++)
 endif()
 
+# rocdecode-host Version
+set(VERSION "1.0.0")
+
 # Set Project Version and Language
-project(rocdecodehost VERSION ${VERSION} LANGUAGES CXX)
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
+project(rocdecode-host VERSION ${VERSION} LANGUAGES CXX)
+
+# add cmake find Config locations
 list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
 
-set(DEFAULT_BUILD_TYPE "Release")
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}" CACHE STRING "rocdecode-host Default Build Type" FORCE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
-endif()
-if(CMAKE_BUILD_TYPE MATCHES Debug)
-  # -O0 -- Don't Optimize output file 
-  # -gdwarf-4  -- generate debugging information, dwarf-4 for making valgrind work
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -gdwarf-4 -Wall")
-else()
-  # -O3       -- Optimize output file 
-  # -DNDEBUG  -- turn off asserts 
-  # -fPIC     -- Generate position-independent code if possible
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC -Wall")
-endif()
-
-message("-- ${BoldBlue}rocdecode-host Build Type -- ${CMAKE_BUILD_TYPE}${ColourReset}")
-
+find_package(HIP QUIET)
+find_package(Threads QUIET)
 find_package(rocprofiler-register QUIET)
 find_package(FFmpeg QUIET)
 
-if(HIP_FOUND AND FFMPEG_FOUND AND Threads_FOUND AND rocprofiler-register_FOUND)
+if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
   # HIP
   set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} hip::host)
   # FFMPEG
@@ -82,7 +70,7 @@ if(HIP_FOUND AND FFMPEG_FOUND AND Threads_FOUND AND rocprofiler-register_FOUND)
   include_directories(api rocdecode-host ../src/rocdecode ../src/parser)
   # source files
   file(GLOB_RECURSE SOURCES "./*.cpp")
-  # rocdecode.so
+  # rocdecode-host.so
   add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
   target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})
@@ -93,22 +81,25 @@ if(HIP_FOUND AND FFMPEG_FOUND AND Threads_FOUND AND rocprofiler-register_FOUND)
     target_compile_definitions(${PROJECT_NAME} PUBLIC USE_AVCODEC_GREATER_THAN_58_134=1)
   endif()
   set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+  # install rocdecode-host libs -- {ROCM_PATH}/lib
+  set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+  install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime NAMELINK_SKIP)
+  install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}-targets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev NAMELINK_ONLY)
+  install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT asan)
+  # install rocdecode include files -- {ROCM_PATH}/include/rocdecode
+  install(FILES ${PROJECT_SOURCE_DIR}/../../api/rocdecode/rocdecode_host.h 
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME} COMPONENT dev)
+
 else()
   message("-- ERROR!: ${PROJECT_NAME} excluded! please install all the dependencies and try again!")
   if (NOT HIP_FOUND)
       message(FATAL_ERROR "-- ERROR!: HIP Not Found! - please install ROCm and HIP!")
   endif()
-  if (NOT FFMPEG_FOUND)
-      message(FATAL_ERROR "-- ERROR!: FFMPEG Not Found! - please install FFMPEG!")
-  endif()
   if (NOT Threads_FOUND)
       message(FATAL_ERROR "-- ERROR!: Threads Not Found! - please install Threads!")
   endif()
-  if (NOT rocprofiler-register_FOUND)
-      message(FATAL_ERROR "-- ERROR!: rocprofiler-register Not Found! - please install rocprofiler-register!")
+  if (NOT FFMPEG_FOUND)
+      message(FATAL_ERROR "-- ERROR!: FFMPEG Not Found! - please install FFMPEG!")
   endif()
 endif()
-
-  # install rocdecode-host libs -- {ROCM_PATH}/lib
-  set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
-  install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT dev)


### PR DESCRIPTION
## Motivation

rocDecode host fix for issue #640 

## Technical Details
RHEL Failures
```
CPack: Create package
CMake Warning (dev) at /usr/local/lib64/python3.12/site-packages/cmake/data/share/cmake-3.25/Modules/Internal/CPack/CPackRPM.cmake:1493 (message):
  CPackRPM:Warning: debuginfo package was requested but will not be generated
  as no source files were found! Component: 'dev'.
Call Stack (most recent call first):
  /usr/local/lib64/python3.12/site-packages/cmake/data/share/cmake-3.25/Modules/Internal/CPack/CPackRPM.cmake:1968 (cpack_rpm_generate_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

## Test Plan

RHEL 10 packages will build

## Test Result

RHEL 10 packages available

## Submission Checklist

- [ X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
