### PR TITLE
removing SP6

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ You can find rocDecode Docker containers in our
 * Linux
   * Ubuntu - `22.04` / `24.04`
   * RHEL - `8` / `9`
-  * SLES - `15 SP6` / `15 SP7`
+  * SLES - `15 SP7`
 * ROCm: `7.0.0`
 * libva-amdgpu-dev - `2.16.0`
 * mesa-amdgpu-va-drivers - `1:24.3.0`

--- a/docs/install/rocDecode-prerequisites.rst
+++ b/docs/install/rocDecode-prerequisites.rst
@@ -18,7 +18,7 @@ rocDecode has been tested on the following Linux environments:
   
 * Ubuntu 22.04 and 24.04
 * RHEL 8 and 9
-* SLES 15 SP6 and SP7
+* SLES 15 SP7
 
 See `Supported operating systems <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html#supported-operating-systems>`_ for the complete list of ROCm supported Linux environments.
 


### PR DESCRIPTION
## Motivation

SLES SP6 isn't supported in rocm 7.0