### PR TITLE
Drop libva-amdgpu for RHEL 9+ and SLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,10 +304,9 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   # Set the dependent packages
   # libva 2.16 (API 1.16) is needed to use mesa-amdgpu-va-drivers, libva-amdgpu
   # (AMD build of libva 2.16) should be used if distro's libva is too old
-  # Libva is 2.12 on Ubuntu 22.04 and 24.04, so we can always use libva-amdgpu
-  set(ROCDECODE_DEBIAN_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, libva2-amdgpu, libva-amdgpu-drm2, libva-amdgpu-wayland2, libva-amdgpu-x11-2, mesa-amdgpu-va-drivers")
-  # Unfortunately RPM has a mix of versions; RHEL has "libva", SLE has "libva2"
-  set(ROCDECODE_RPM_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, (libva >= 2.16.0 or libva2 >= 2.16.0 or libva-amdgpu), mesa-amdgpu-va-drivers")
+  set(ROCDECODE_DEBIAN_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, libva-drm2 (>= 2.16.0) | libva-amdgpu-drm2, mesa-amdgpu-va-drivers")
+  # Unfortunately RPM has a mix of naming schemes; RHEL has "libva", SLE has "libva2-drm2"
+  set(ROCDECODE_RPM_RUNTIME_PACKAGE_LIST  "rocm-hip-runtime, (libva >= 2.16.0 or libva-drm2 >= 2.16.0 or libva-amdgpu), mesa-amdgpu-va-drivers")
   # Add rocprofiler-register dependencies
   if(ROCDECODE_ENABLE_ROCPROFILER_REGISTER)
     set(ROCDECODE_DEBIAN_RUNTIME_PACKAGE_LIST "${ROCDECODE_DEBIAN_RUNTIME_PACKAGE_LIST}, rocprofiler-register")
@@ -315,12 +314,12 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   endif()
 
   # Set the dev dependent packages
-  set(ROCDECODE_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-amdgpu-dev, pkg-config, libavcodec-dev, libavformat-dev, libavutil-dev")
+  set(ROCDECODE_DEBIAN_DEV_PACKAGE_LIST  "rocm-hip-runtime-dev, libva-dev (>= 2.16.0) | libva-amdgpu-dev, pkg-config, libavcodec-dev, libavformat-dev, libavutil-dev")
   if(UBUNTU_22_FOUND)
     set(ROCDECODE_DEBIAN_DEV_PACKAGE_LIST "${ROCDECODE_DEBIAN_DEV_PACKAGE_LIST}, libstdc++-12-dev")
   endif()
   # TBD - RPM packages need Fusion Packages - "libavcodec-devel, libavformat-devel, libavutil-devel"
-  set(ROCDECODE_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, libva-amdgpu-devel, pkg-config")
+  set(ROCDECODE_RPM_DEV_PACKAGE_LIST  "rocm-hip-runtime-devel, (libva-devel >= 2.16.0 or libva-amdgpu-devel), pkg-config")
   
   # '%{?dist}' breaks manual builds on debian systems due to empty Provides
   execute_process(
@@ -434,9 +433,9 @@ else()
     message(FATAL_ERROR "-- ERROR!: HIP Not Found! - please install rocm-hip-runtime-dev!")
   endif()
   if(NOT Libva_FOUND)
-    message(FATAL_ERROR "-- ERROR!: libva Not Found - please install libva-amdgpu-dev/libva-amdgpu-devel!")
+    message(FATAL_ERROR "-- ERROR!: libva Not Found - please install libva-dev/libva-devel!")
   endif()
   if(NOT Libdrm_amdgpu_FOUND)
-    message(FATAL_ERROR "-- ERROR!: libdrm_amdgpu Not Found - please install libdrm-amdgpu-dev(DEBIAN)/libdrm-amdgpu-devel(RPM) package!")
+    message(FATAL_ERROR "-- ERROR!: libdrm_amdgpu Not Found - please install libdrm-dev(DEBIAN)/libdrm-devel(RPM) package!")
   endif()
 endif()

--- a/cmake/FindLibva.cmake
+++ b/cmake/FindLibva.cmake
@@ -23,7 +23,7 @@
 
 find_library(LIBVA_LIBRARY NAMES va HINTS /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
 find_library(LIBVA_DRM_LIBRARY NAMES va-drm HINTS /opt/amdgpu/lib/x86_64-linux-gnu /opt/amdgpu/lib64 /usr/lib/x86_64-linux-gnu /usr/lib64)
-find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS /opt/amdgpu/include NO_DEFAULT_PATH)
+find_path(LIBVA_INCLUDE_DIR NAMES va/va.h PATHS /opt/amdgpu/include /usr/include NO_DEFAULT_PATH)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libva DEFAULT_MSG LIBVA_INCLUDE_DIR LIBVA_LIBRARY)

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -260,7 +260,7 @@ if runtimeInstall == 'ON':
             for i in range(len(runtimeDebianU22Packages)):
                 ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
                     ' '+linuxSystemInstall_check+' install '+ runtimeDebianU22Packages[i]))
-        else
+        else:
             for i in range(len(runtimeDebianPackages)):
                 ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
                     ' '+linuxSystemInstall_check+' install '+ runtimeDebianPackages[i]))

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -172,7 +172,7 @@ coreDebianPackages = [
 ]
 coreDebianU22Packages = [
     'libva-amdgpu-dev',
-    'rocm-hip-runtime-dev'
+    'rocm-hip-runtime-dev',
     'libstdc++-12-dev'
 ]
 runtimeDebianPackages = [

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -167,13 +167,20 @@ commonPackages = [
 
 # Debian packages
 coreDebianPackages = [
-    'libva-amdgpu-dev',
+    'libva-dev',
     'rocm-hip-runtime-dev'
 ]
 coreDebianU22Packages = [
+    'libva-amdgpu-dev',
+    'rocm-hip-runtime-dev'
     'libstdc++-12-dev'
 ]
 runtimeDebianPackages = [
+    'libva-drm2',
+    'mesa-amdgpu-va-drivers',
+    'vainfo'
+]
+runtimeDebianU22Packages = [
     'libva2-amdgpu',
     'libva-amdgpu-drm2',
     'libva-amdgpu-wayland2',
@@ -188,15 +195,37 @@ ffmpegDebianPackages = [
 ]
 
 # RPM Packages
-coreRPMPackages = [
-    'libva-amdgpu-devel',
-    'rocm-hip-runtime-devel'
-]
-runtimeRPMPackages = [
-    'libva-amdgpu',
-    'mesa-amdgpu-va-drivers',
-    'libva-utils'
-]
+if "centos" in os_info_data or "redhat" in os_info_data:
+    if "VERSION_ID=7" in os_info_data or "VERSION_ID=8" in os_info_data:
+        coreRPMPackages = [
+            'libva-amdgpu-devel',
+            'rocm-hip-runtime-devel'
+        ]
+        runtimeRPMPackages = [
+            'libva-amdgpu',
+            'mesa-amdgpu-va-drivers',
+            'libva-utils'
+        ]
+    else:
+        coreRPMPackages = [
+            'libva-devel',
+            'rocm-hip-runtime-devel'
+        ]
+        runtimeRPMPackages = [
+            'libva',
+            'mesa-amdgpu-va-drivers',
+            'libva-utils'
+        ]
+else:
+    coreRPMPackages = [
+        'libva-devel',
+        'rocm-hip-runtime-devel'
+    ]
+    runtimeRPMPackages = [
+        'libva-drm2',
+        'mesa-amdgpu-va-drivers',
+        'libva-utils'
+    ]
 
 # update
 ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +' '+linuxSystemInstall_check+' '+osUpdate))
@@ -210,13 +239,14 @@ for i in range(len(commonPackages)):
 # rocDecode Core - Requirements
 ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 if "Ubuntu" in platfromInfo:
-    for i in range(len(coreDebianPackages)):
-        ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
-                ' '+linuxSystemInstall_check+' install '+ coreDebianPackages[i]))
     if "VERSION_ID=22" in os_info_data:
         for i in range(len(coreDebianU22Packages)):
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
                     ' '+linuxSystemInstall_check+' install '+ coreDebianU22Packages[i]))
+    else
+        for i in range(len(coreDebianPackages)):
+            ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                    ' '+linuxSystemInstall_check+' install '+ coreDebianPackages[i]))
 else:
     for i in range(len(coreRPMPackages)):
         ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
@@ -226,9 +256,14 @@ else:
 ERROR_CHECK(os.system('sudo '+sudoValidateOption))
 if runtimeInstall == 'ON':
     if "Ubuntu" in platfromInfo:
-        for i in range(len(runtimeDebianPackages)):
-            ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
-                ' '+linuxSystemInstall_check+' install '+ runtimeDebianPackages[i]))
+        if "VERSION_ID=22" in os_info_data:
+            for i in range(len(runtimeDebianU22Packages)):
+                ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                    ' '+linuxSystemInstall_check+' install '+ runtimeDebianU22Packages[i]))
+        else
+            for i in range(len(runtimeDebianPackages)):
+                ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
+                    ' '+linuxSystemInstall_check+' install '+ runtimeDebianPackages[i]))
     else:
         for i in range(len(runtimeRPMPackages)):
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +

--- a/rocDecode-setup.py
+++ b/rocDecode-setup.py
@@ -243,7 +243,7 @@ if "Ubuntu" in platfromInfo:
         for i in range(len(coreDebianU22Packages)):
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
                     ' '+linuxSystemInstall_check+' install '+ coreDebianU22Packages[i]))
-    else
+    else:
         for i in range(len(coreDebianPackages)):
             ERROR_CHECK(os.system('sudo '+linuxFlag+' '+linuxSystemInstall +
                     ' '+linuxSystemInstall_check+' install '+ coreDebianPackages[i]))


### PR DESCRIPTION
Due to limitations in RPM packaging, having libva-amdgpu packages just causes bugs due to edge cases. It's easier to just use the inbox packages for RHEL9+ and SLE.

I also noticed that SLE should be pulling in libva-drm2 as a runtime requirement.

SWDEV-555510

Note: I have not fully tested this, I will need some help to make sure the python script is good.