### PR TITLE
Added logging control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 Full documentation for rocDecode is available at [https://rocm.docs.amd.com/projects/rocDecode/en/latest/](https://rocm.docs.amd.com/projects/rocDecode/en/latest/)
 
-## (Unreleased) rocDecode 1.5.0
+## (Unreleased) rocDecode 1.5.1
 
 ### Changed
 * Updated libdrm path configuration and libva version requirements for ROCm and TheRock platforms
+
+### Added
+* Logging control. Message output from the core components is now controlled by the log level, which can be set by an environment variable or other methods.
 
 ## rocDecode 1.4.0 for ROCm 7.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 * Updated libdrm path configuration and libva version requirements for ROCm and TheRock platforms
 
 ### Added
-* Logging control. Message output from the core components is now controlled by the log level, which can be set by an environment variable or other methods.
+* Logging control. Message output from the core components is now controlled by the logging level threshold, which can be set by an environment variable or other methods.
 
 ## rocDecode 1.4.0 for ROCm 7.1.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if (NOT DEFINED CMAKE_CXX_COMPILER)
 endif()
 
 # rocdecode Version
-set(VERSION "1.5.0")
+set(VERSION "1.5.1")
 
 # Set Project Version and Language
 project(rocdecode VERSION ${VERSION} LANGUAGES CXX)

--- a/docs/how-to/using-rocdecode.rst
+++ b/docs/how-to/using-rocdecode.rst
@@ -220,7 +220,7 @@ resources at the end of video decoding.
 
 Logging control
 ====================================================
-rocDecode core components can generate various logs during the decode session. The logs can be critical status reports, error reports, warnings, etc. Each log has a significance level associated to it. The level can be from critical (0) to debug info related (4). Lower value has greater importance. An internal logging level can be set to control the verbosity of logging output from each rocDecode component. If a log's level value is less than or equal to the logging levle, the log is output. Otherwise, the log is not output.
+rocDecode core components can generate various logs during the decode session. The logs can be critical status reports, error reports, warnings, etc. Each log has a significance level associated to it. The level can be from critical (0) to debug info related (4). Lower value has greater importance. An internal logging level can be set to control the verbosity of logging output from each rocDecode component. If a log's level value is less than or equal to the logging level, the log is output. Otherwise, the log is not output.
 
 The logging level can be set by the environment variable ROCDEC_LOG_LEVEL, or by calling the SetLogLevel method of the logger class. The default logging level is 0 (critical log only).
 

--- a/docs/how-to/using-rocdecode.rst
+++ b/docs/how-to/using-rocdecode.rst
@@ -218,6 +218,12 @@ Destroy the parser
 You need to call ``rocDecDestroyVideoParser()`` to destroy the parser object and free up all allocated
 resources at the end of video decoding.
 
+Logging control
+====================================================
+rocDecode core components can generate various logs during the decode session. The logs can be critical status reports, error reports, warnings, etc. Each log has a significance level associated to it. The level can be from critical (0) to debug info related (4). Lower value has greater importance. An internal logging level can be set to control the verbosity of logging output from each rocDecode component. If a log's level value is less than or equal to the logging levle, the log is output. Otherwise, the log is not output.
+
+The logging level can be set by the environment variable ROCDEC_LOG_LEVEL, or by calling the SetLogLevel method of the logger class. The default logging level is 0 (critical log only).
+
 
 .. |apifolder| replace:: ``api`` folder
 .. _apifolder: https://github.com/ROCm/rocDecode/tree/develop/api

--- a/docs/how-to/using-rocdecode.rst
+++ b/docs/how-to/using-rocdecode.rst
@@ -220,9 +220,13 @@ resources at the end of video decoding.
 
 Logging control
 ====================================================
-rocDecode core components can generate various logs during the decode session. The logs can be critical status reports, error reports, warnings, etc. Each log has a significance level associated to it. The level can be from critical (0) to debug info related (4). Lower value has greater importance. An internal logging level can be set to control the verbosity of logging output from each rocDecode component. If a log's level value is less than or equal to the logging level, the log is output. Otherwise, the log is not output.
+rocDecode core components can generate various logs during the decode session. The logs can be critical status reports, error reports, warnings, etc. 
+Each log has a significance level associated to it. The level can be from critical (0) to debug info related (4). Lower value has greater importance. 
+An internal logging level threshold can be set to control the verbosity of logging output from each rocDecode component. If a log's level value is less 
+than or equal to the logging level threshold, the log is output. Otherwise, the log is not output.
 
-The logging level can be set by the environment variable ROCDEC_LOG_LEVEL, or by calling the SetLogLevel method of the logger class. The default logging level is 0 (critical log only).
+The logging level threshold can be set by the environment variable ROCDEC_LOG_LEVEL, or by calling the SetLogLevel method of the logger class. The default 
+logging level is 0 (critical log only).
 
 
 .. |apifolder| replace:: ``api`` folder

--- a/src/bit_stream_reader/es_reader.cpp
+++ b/src/bit_stream_reader/es_reader.cpp
@@ -26,12 +26,13 @@ THE SOFTWARE.
 #include "avc_defines.h"
 #include "av1_defines.h"
 #include "vp9_defines.h"
-#include "roc_video_parser.h"
 
 RocVideoESParser::RocVideoESParser(const char *input_file_path) {
+    logger_.SetLogLevel(kRocDecLogError);
+
     p_stream_file_.open(input_file_path, std::ifstream::in | std::ifstream::binary);
     if (!p_stream_file_) {
-        ERR("Failed to open the bitstream file.");
+        logger_.CriticalLog(MakeMsg("Failed to open the bitstream file."));
     }
     end_of_file_ = false;
     end_of_stream_ = false;
@@ -138,7 +139,7 @@ bool RocVideoESParser::ReadBytes(int offset, int size, uint8_t *data) {
             return false;
         }
         if (size > GetDataSizeInRB()) {
-            ERR("Could not read the requested bytes from ring buffer. Either ring buffer size is too small or not enough bytes left.");
+            logger_.CriticalLog(MakeMsg("Could not read the requested bytes from ring buffer. Either ring buffer size is too small or not enough bytes left."));
             return false;
         }
     }
@@ -297,7 +298,7 @@ int RocVideoESParser::GetPicDataAvcHevc(uint8_t **p_pic_data, int *pic_size) {
 
     while (!end_of_stream_) {
         if (!FindStartCode()) {
-            ERR("No start code in the bitstream.");
+            logger_.ErrorLog(MakeMsg("No start code in the bitstream."));
             break;
         }
         CopyNalUnitFromRing();

--- a/src/bit_stream_reader/es_reader.h
+++ b/src/bit_stream_reader/es_reader.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include <fstream>
 #include <vector>
 #include "rocdecode/rocdecode.h"
+#include "roc_video_parser.h"
 
 #define BS_RING_SIZE (16 * 1024 * 1024)
 #define INIT_PIC_DATA_SIZE (2 * 1024 * 1024)
@@ -99,6 +100,8 @@ class RocVideoESParser {
         int num_temp_units_; // number of temporal units
 
         bool ivf_file_header_read_; // indicator if IVF file header has been checked
+
+        RocDecLogger logger_;
 
         /*! \brief Function to retrieve the bitstream of a picture for AVC/HEVC
          * \param [out] p_pic_data Pointer to the picture data

--- a/src/bit_stream_reader/roc_bs_reader_api.cpp
+++ b/src/bit_stream_reader/roc_bs_reader_api.cpp
@@ -33,7 +33,7 @@ rocDecStatus ROCDECAPI rocDecCreateBitstreamReader(RocdecBitstreamReader *bs_rea
         handle = new RocBitstreamReaderHandle(input_file_path);
     } 
     catch (const std::exception& e) {
-        ERR( STR("Failed to create RocBitstreamReader handle, ") + STR(e.what()))
+        RocDecLogger::AlwaysLog(STR("Failed to create RocBitstreamReader handle, ") + STR(e.what()));
         return ROCDEC_RUNTIME_ERROR;
     }
     *bs_reader_handle = handle;
@@ -51,7 +51,7 @@ rocDecStatus ROCDECAPI rocDecGetBitstreamCodecType(RocdecBitstreamReader bs_read
     }
     catch (const std::exception& e) {
         roc_bs_reader_handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;
@@ -68,7 +68,7 @@ rocDecStatus ROCDECAPI rocDecGetBitstreamBitDepth(RocdecBitstreamReader bs_reade
     }
     catch (const std::exception& e) {
         roc_bs_reader_handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;
@@ -85,7 +85,7 @@ rocDecStatus ROCDECAPI rocDecGetBitstreamPicData(RocdecBitstreamReader bs_reader
     }
     catch (const std::exception& e) {
         roc_bs_reader_handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;

--- a/src/commons.h
+++ b/src/commons.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include <exception>
 #include <string>
 #include <iostream>
+#include <algorithm>
 
 #define TOSTR(X) std::to_string(static_cast<int>(X))
 #define STR(X) std::string(X)
@@ -40,11 +41,75 @@ THE SOFTWARE.
 #endif
 #define ERR(X) std::cerr << "[ERR] "  << " {" << __func__ <<"} " << " " << X << std::endl;
 
+// Logging control
+enum RocDecLogLevel {
+    kRocDecLogCritical       = 0,  // Only ouput critical messages
+    kRocDecLogError          = 1,
+    kRocDecLogWarning        = 2,
+    kRocDecLogInfo           = 3,
+    kRocDecLogDebug          = 4,
+    kRocDecLogLevelMax       = 4
+};
+
+#define MakeMsg(msg) STR(__func__) + "(), Line " + TOSTR(__LINE__) + ": " + msg
+#define OutputMsg(msg) std::cout << msg << std::endl
+
+class RocDecLogger {
+public:
+    RocDecLogger() : log_level_(kRocDecLogCritical) {
+        char *env_log_level = std::getenv("ROCDEC_LOG_LEVEL");
+        if (env_log_level != nullptr) {
+            log_level_ = std::clamp(std::atoi(env_log_level), 0, static_cast<int>(kRocDecLogLevelMax));
+        }
+    }
+    RocDecLogger(int log_level) : log_level_(log_level) {};
+    ~RocDecLogger() {};
+
+    void SetLogLevel(int log_level) {log_level_ = std::clamp(log_level, 0, static_cast<int>(kRocDecLogLevelMax));};
+    int GetLogLevel() {return log_level_;};
+
+    static void AlwaysLog(std::string msg) {
+        OutputMsg(msg);
+    };
+
+    void CriticalLog(std::string msg) {
+        if (log_level_ >= kRocDecLogCritical) {
+            OutputMsg("[Critical] " + msg);
+        }
+    };
+
+    void ErrorLog(std::string msg) {
+        if (log_level_ >= kRocDecLogError) {
+            OutputMsg("[Error] " + msg);
+        }
+    };
+
+    void WarningLog(std::string msg) {
+        if (log_level_ >= kRocDecLogWarning) {
+            OutputMsg("[Warning] " + msg);
+        }
+    };
+
+    void InfoLog(std::string msg) {
+        if (log_level_ >= kRocDecLogInfo) {
+            OutputMsg("[Info] " + msg);
+        }
+    };
+
+    void DebugLog(std::string msg) {
+        if (log_level_ >= kRocDecLogDebug) {
+            OutputMsg("[Debug] " + msg);
+        }
+    };
+
+private:
+    int log_level_ = kRocDecLogCritical;
+};
 
 class rocDecodeException : public std::exception {
 public:
 
-    explicit rocDecodeException(const std::string& message):_message(message){}
+    explicit rocDecodeException(const std::string& OutputMsg):_message(OutputMsg){}
     virtual const char* what() const throw() override {
         return _message.c_str();
     }

--- a/src/parser/av1_parser.cpp
+++ b/src/parser/av1_parser.cpp
@@ -58,7 +58,7 @@ rocDecStatus Av1VideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     if (p_data->payload && p_data->payload_size) {
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
-            ERR("Error occurred in picture data parsing.");
+            logger_.ErrorLog(MakeMsg("Error occurred in picture data parsing."));
             return ROCDEC_RUNTIME_ERROR;
         }
     } else if (!(p_data->flags & ROCDEC_PKT_ENDOFSTREAM)) {
@@ -91,7 +91,7 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
             }
             case kObuFrameHeader: {
                 if (seen_frame_header_ != 0) {
-                    ERR("If obu_type is equal to OBU_FRAME_HEADER, it is a requirement of bitstream conformance that SeenFrameHeader is equal to 0.");
+                    logger_.ErrorLog(MakeMsg("If obu_type is equal to OBU_FRAME_HEADER, it is a requirement of bitstream conformance that SeenFrameHeader is equal to 0."));
                     return PARSER_INVALID_ARG;
                 }
                 int bytes_parsed;
@@ -102,7 +102,7 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
             }
             case kObuRedundantFrameHeader: {
                 if (seen_frame_header_ != 1) {
-                    ERR("If obu_type is equal to OBU_REDUNDANT_FRAME_HEADER, it is a requirement of bitstream conformance that SeenFrameHeader is equal to 1.");
+                    logger_.ErrorLog(MakeMsg("If obu_type is equal to OBU_REDUNDANT_FRAME_HEADER, it is a requirement of bitstream conformance that SeenFrameHeader is equal to 1."));
                     return PARSER_INVALID_ARG;
                 }
                 int bytes_parsed;
@@ -120,18 +120,18 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                 if (obu_size_ > bytes_parsed) {
                     obu_size_ -= bytes_parsed;
                     if (ParseTileGroupObu(pic_data_buffer_ptr_ + obu_byte_offset_, obu_size_) != PARSER_OK) {
-                        ERR("Error occurred in ParseTileGroupObu(). Skip this OBU.");
+                        logger_.ErrorLog(MakeMsg("Error occurred in ParseTileGroupObu(). Skip this OBU."));
                         break;
                     }
                 } else {
-                    ERR("Frame OBU size error.");
+                    logger_.ErrorLog(MakeMsg("Frame OBU size error."));
                     return PARSER_OUT_OF_RANGE;
                 }
                 break;
             }
             case kObuTileGroup: {
                 if (ParseTileGroupObu(pic_data_buffer_ptr_ + obu_byte_offset_, obu_size_) != PARSER_OK) {
-                    ERR("Error occurred in ParseTileGroupObu(). Skip this OBU.");
+                    logger_.ErrorLog(MakeMsg("Error occurred in ParseTileGroupObu(). Skip this OBU."));
                 }
                 break;
             }
@@ -151,7 +151,7 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
         if (frame_header_.show_existing_frame) {
             int disp_idx = dpb_buffer_.virtual_buffer_index[frame_header_.frame_to_show_map_idx];
             if (disp_idx == INVALID_INDEX) {
-                ERR("Invalid existing frame index to show.");
+                logger_.ErrorLog(MakeMsg("Invalid existing frame index to show."));
                 return PARSER_INVALID_ARG;
             }
             if (pfn_display_picture_cb_) {
@@ -164,7 +164,7 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                 decode_buffer_pool_[disp_idx].pts = curr_pts_;
                 // Insert into output/display picture list
                 if (num_output_pics_ >= dec_buf_pool_size_) {
-                    ERR("Display list size larger than decode buffer pool size!");
+                    logger_.ErrorLog(MakeMsg("Display list size larger than decode buffer pool size!"));
                     return PARSER_OUT_OF_RANGE;
                 } else {
                     output_pic_list_[num_output_pics_] = disp_idx;
@@ -182,7 +182,7 @@ ParserResult Av1VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                 return ret;
             }
             if ((ret = SendPicForDecode()) != PARSER_OK) {
-                ERR(STR("Failed to decode!"));
+                logger_.ErrorLog(MakeMsg(STR("Failed to decode!")));
                 return ret;
             }
             pic_count_++;
@@ -218,7 +218,7 @@ ParserResult Av1VideoParser::NotifyNewSequence(Av1SequenceHeader *p_seq_header, 
     } else if (p_seq_header->color_config.mono_chrome == 0 && p_seq_header->color_config.subsampling_x == 0 && p_seq_header->color_config.subsampling_y == 0) {
         video_format_params_.chroma_format = rocDecVideoChromaFormat_444;
     } else {
-        ERR("Incorrect chroma format.");
+        logger_.ErrorLog(MakeMsg("Incorrect chroma format."));
         return PARSER_INVALID_FORMAT;
     }
 
@@ -243,7 +243,7 @@ ParserResult Av1VideoParser::NotifyNewSequence(Av1SequenceHeader *p_seq_header, 
 
     // callback function with RocdecVideoFormat params filled out
     if (pfn_sequence_cb_(parser_params_.user_data, &video_format_params_) == 0) {
-        ERR("Sequence callback function failed.");
+        logger_.ErrorLog(MakeMsg("Sequence callback function failed."));
         return PARSER_FAIL;
     } else {
         return PARSER_OK;
@@ -479,7 +479,7 @@ ParserResult Av1VideoParser::SendPicForDecode() {
 #endif // DBGINFO
 
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
-        ERR("Decode error occurred.");
+        logger_.ErrorLog(MakeMsg("Decode error occurred."));
         return PARSER_FAIL;
     } else {
         return PARSER_OK;
@@ -620,7 +620,7 @@ ParserResult Av1VideoParser::FindFreeInDecBufPool() {
         }
     }
     if (dec_buf_index == dec_buf_pool_size_) {
-        ERR("Could not find a free buffer in decode buffer pool for decoded image.");
+        logger_.ErrorLog(MakeMsg("Could not find a free buffer in decode buffer pool for decoded image."));
         return PARSER_NOT_FOUND;
     }
     curr_pic_.dec_buf_idx = dec_buf_index;
@@ -635,7 +635,7 @@ ParserResult Av1VideoParser::FindFreeInDecBufPool() {
             }
         }
         if (dec_buf_index == dec_buf_pool_size_) {
-            ERR("Could not find a free buffer in decode buffer pool for FG output.");
+            logger_.ErrorLog(MakeMsg("Could not find a free buffer in decode buffer pool for FG output."));
             return PARSER_NOT_FOUND;
         }
         curr_pic_.fg_buf_idx = dec_buf_index;
@@ -656,7 +656,7 @@ ParserResult Av1VideoParser::FindFreeInDpbAndMark() {
         }
     }
     if (i == BUFFER_POOL_MAX_SIZE) {
-        ERR("DPB buffer overflow!");
+        logger_.ErrorLog(MakeMsg("DPB buffer overflow!"));
         return PARSER_NOT_FOUND;
     }
     curr_pic_.pic_idx = i;
@@ -675,7 +675,7 @@ ParserResult Av1VideoParser::FindFreeInDpbAndMark() {
         decode_buffer_pool_[disp_idx].pts = curr_pts_;
         // Insert into output/display picture list
         if (num_output_pics_ >= dec_buf_pool_size_) {
-            ERR("Display list size larger than decode buffer pool size!");
+            logger_.ErrorLog(MakeMsg("Display list size larger than decode buffer pool size!"));
             return PARSER_OUT_OF_RANGE;
         } else {
             output_pic_list_[num_output_pics_] = disp_idx;
@@ -699,18 +699,18 @@ ParserResult Av1VideoParser::ParseObuHeader(const uint8_t *p_stream) {
     size_t offset = 0;
     obu_header_.size = 1;
     if (Parser::GetBit(p_stream, offset) != 0) {
-        ERR("Syntax error: obu_forbidden_bit must be set to 0.");
+        logger_.ErrorLog(MakeMsg("Syntax error: obu_forbidden_bit must be set to 0."));
         return PARSER_INVALID_ARG;
     }
     obu_header_.obu_type = Parser::ReadBits(p_stream, offset, 4);
     obu_header_.obu_extension_flag = Parser::GetBit(p_stream, offset);
     obu_header_.obu_has_size_field = Parser::GetBit(p_stream, offset);
     if (!obu_header_.obu_has_size_field) {
-        ERR("Syntax error: Section 5.2: obu_has_size_field must be equal to 1.");
+        logger_.ErrorLog(MakeMsg("Syntax error: Section 5.2: obu_has_size_field must be equal to 1."));
         return PARSER_INVALID_ARG;
     }
     if (Parser::GetBit(p_stream, offset) != 0) {
-        ERR("Syntax error: obu_reserved_1bit must be set to 0.");
+        logger_.ErrorLog(MakeMsg("Syntax error: obu_reserved_1bit must be set to 0."));
         return PARSER_INVALID_ARG;
     }
     if (obu_header_.obu_extension_flag) {
@@ -718,7 +718,7 @@ ParserResult Av1VideoParser::ParseObuHeader(const uint8_t *p_stream) {
         obu_header_.temporal_id = Parser::ReadBits(p_stream, offset, 3);
         obu_header_.spatial_id = Parser::ReadBits(p_stream, offset, 2);
         if (Parser::ReadBits(p_stream, offset, 3) != 0) {
-            ERR("Syntax error: extension_header_reserved_3bits must be set to 0.");
+            logger_.ErrorLog(MakeMsg("Syntax error: extension_header_reserved_3bits must be set to 0."));
             return PARSER_INVALID_ARG;
         }
     }
@@ -731,7 +731,7 @@ ParserResult Av1VideoParser::ReadObuHeaderAndSize() {
     }
     uint8_t *p_stream = pic_data_buffer_ptr_ + curr_byte_offset_;
     if (ParseObuHeader(p_stream) != PARSER_OK) {
-        ERR("Syntax error(s) found in OBU header.")
+        logger_.ErrorLog(MakeMsg("Syntax error(s) found in OBU header."));
     }
     curr_byte_offset_ += obu_header_.size;
     p_stream += obu_header_.size;
@@ -741,7 +741,7 @@ ParserResult Av1VideoParser::ReadObuHeaderAndSize() {
     obu_byte_offset_ = curr_byte_offset_ + bytes_read;
     curr_byte_offset_ = obu_byte_offset_ + obu_size_;
     if (curr_byte_offset_ > pic_data_size_) {
-        ERR("Invalid obu_size value.");
+        logger_.ErrorLog(MakeMsg("Invalid obu_size value."));
         return PARSER_EOF;
     } else {
         return PARSER_OK;
@@ -758,7 +758,7 @@ ParserResult Av1VideoParser::ParseSequenceHeaderObu(uint8_t *p_stream, size_t si
     p_seq_header->still_picture = Parser::GetBit(p_stream, offset);
     p_seq_header->reduced_still_picture_header = Parser::GetBit(p_stream, offset);
     if (p_seq_header->reduced_still_picture_header == 1 && p_seq_header->still_picture != 1) {
-        ERR("If reduced_still_picture_header is 1, still_picture is required to be 1.");
+        logger_.ErrorLog(MakeMsg("If reduced_still_picture_header is 1, still_picture is required to be 1."));
         return PARSER_WRONG_STATE;
     }
 
@@ -778,12 +778,12 @@ ParserResult Av1VideoParser::ParseSequenceHeaderObu(uint8_t *p_stream, size_t si
             // timing_info()
             p_seq_header->timing_info.num_units_in_display_tick = Parser::ReadBits(p_stream, offset, 32);
             if (p_seq_header->timing_info.num_units_in_display_tick == 0) {
-                ERR("num_units_in_display_tick is 0.");
+                logger_.ErrorLog(MakeMsg("num_units_in_display_tick is 0."));
                 return PARSER_WRONG_STATE;
             }
             p_seq_header->timing_info.time_scale = Parser::ReadBits(p_stream, offset, 32);
             if (p_seq_header->timing_info.time_scale == 0) {
-                ERR("time_scale is 0.");
+                logger_.ErrorLog(MakeMsg("time_scale is 0."));
                 return PARSER_WRONG_STATE;
             }
             p_seq_header->timing_info.equal_picture_interval = Parser::GetBit(p_stream, offset);
@@ -809,13 +809,13 @@ ParserResult Av1VideoParser::ParseSequenceHeaderObu(uint8_t *p_stream, size_t si
             if (i > 0) {
                 for (int j = 0; j < i - 1; j++) {
                     if (p_seq_header->operating_point_idc[i] == p_seq_header->operating_point_idc[j]) {
-                        ERR("operating_point_idc[" + TOSTR(i) + "] is equal to operating_point_idc[" + TOSTR(j) + "]");
+                        logger_.ErrorLog(MakeMsg("operating_point_idc[" + TOSTR(i) + "] is equal to operating_point_idc[" + TOSTR(j) + "]"));
                         return PARSER_WRONG_STATE;
                     }
                 }
             }
             if (p_seq_header->operating_point_idc[i] && obu_header_.obu_extension_flag != 1) {
-                ERR("When operating_point_idc is not 0, obu_extension_flag is required to be 1.");
+                logger_.ErrorLog(MakeMsg("When operating_point_idc is not 0, obu_extension_flag is required to be 1."));
                 return PARSER_WRONG_STATE;
             }
             p_seq_header->seq_level_idx[i] = Parser::ReadBits(p_stream, offset, 5);
@@ -962,7 +962,7 @@ ParserResult Av1VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
 
     p_frame_header->is_received = 0;
     if (p_seq_header->is_received == 0) {
-        ERR("No valid sequence header received before frame header.");
+        logger_.ErrorLog(MakeMsg("No valid sequence header received before frame header."));
         return PARSER_WRONG_STATE;
     }
 
@@ -980,7 +980,7 @@ ParserResult Av1VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
         p_frame_header->show_existing_frame = Parser::GetBit(p_stream, offset);
         if (p_frame_header->show_existing_frame == 1) {
             if (obu_header_.obu_type == kObuFrame) {
-                ERR("show_existing_frame is 1 when obu_type is equal to OBU_FRAME.");
+                logger_.ErrorLog(MakeMsg("show_existing_frame is 1 when obu_type is equal to OBU_FRAME."));
                 return PARSER_WRONG_STATE;
             }
             p_frame_header->frame_to_show_map_idx = Parser::ReadBits(p_stream, offset, 3);
@@ -1100,7 +1100,7 @@ ParserResult Av1VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
     } else {
         p_frame_header->refresh_frame_flags = Parser::ReadBits(p_stream, offset, 8);
         if (p_frame_header->frame_type == kIntraOnlyFrame && p_frame_header->refresh_frame_flags == 0xFF) {
-            ERR("When frame_type is equal to INTRA_ONLY_FRAME, it is a requirement of bitstream conformance that refresh_frame_flags is not equal to 0xff.");
+            logger_.ErrorLog(MakeMsg("When frame_type is equal to INTRA_ONLY_FRAME, it is a requirement of bitstream conformance that refresh_frame_flags is not equal to 0xff."));
             return PARSER_WRONG_STATE;
         }
     }
@@ -1145,7 +1145,7 @@ ParserResult Av1VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
                 uint32_t delta_frame_id = p_frame_header->delta_frame_id_minus_1 + 1;
                 p_frame_header->expected_frame_id[i] = ((p_frame_header->current_frame_id + (1 << frame_id_len) - delta_frame_id ) % (1 << frame_id_len));
                 if (p_frame_header->expected_frame_id[i] != dpb_buffer_.ref_frame_id[p_frame_header->ref_frame_idx[i]] || dpb_buffer_.ref_valid[p_frame_header->ref_frame_idx[i]] == 0) {
-                    ERR("Syntax Error: Reference buffer frame ID mismatch.\n");
+                    logger_.ErrorLog(MakeMsg("Syntax Error: Reference buffer frame ID mismatch.\n"));
                     return PARSER_INVALID_ARG;
                 }
             }
@@ -1255,7 +1255,7 @@ ParserResult Av1VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
         }
     }
     if (p_frame_header->coded_lossless == 1 && p_frame_header->delta_q_params.delta_q_present == 1) {
-        ERR("It is a requirement of bitstream conformance that delta_q_present is equal to 0 when CodedLossless is equal to 1.");
+        logger_.ErrorLog(MakeMsg("It is a requirement of bitstream conformance that delta_q_present is equal to 0 when CodedLossless is equal to 1."));
         return PARSER_WRONG_STATE;
     }
 
@@ -1305,7 +1305,7 @@ ParserResult Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
     uint32_t tg_size = size;
 
     if (p_frame_header->is_received == 0) {
-        ERR("No valid frame header received before tile group.");
+        logger_.ErrorLog(MakeMsg("No valid frame header received before tile group."));
         return PARSER_WRONG_STATE;
     }
 
@@ -1318,7 +1318,7 @@ ParserResult Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
     if (p_tile_group->num_tiles > 1) {
         tile_start_and_end_present_flag = Parser::GetBit(p_stream, offset);
         if (obu_header_.obu_type == kObuFrame && tile_start_and_end_present_flag != 0) {
-            ERR("If obu_type is equal to OBU_FRAME, it is a requirement of bitstream conformance that the value of tile_start_and_end_present_flag is equal to 0.");
+            logger_.ErrorLog(MakeMsg("If obu_type is equal to OBU_FRAME, it is a requirement of bitstream conformance that the value of tile_start_and_end_present_flag is equal to 0."));
             return PARSER_WRONG_STATE;
         }
     }
@@ -1329,12 +1329,12 @@ ParserResult Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
         uint32_t tile_bits = p_frame_header->tile_info.tile_cols_log2 + p_frame_header->tile_info.tile_rows_log2;
         p_tile_group->tg_start = Parser::ReadBits(p_stream, offset, tile_bits);
         if (p_tile_group->tg_start != p_tile_group->num_tiles_parsed) {
-            ERR("It is a requirement of bitstream conformance that the value of tg_start (" + TOSTR(p_tile_group->tg_start) + ") is equal to the value of TileNum (" + TOSTR(p_tile_group->num_tiles_parsed) + ") at the point that tile_group_obu is invoked.");
+            logger_.ErrorLog(MakeMsg("It is a requirement of bitstream conformance that the value of tg_start (" + TOSTR(p_tile_group->tg_start) + ") is equal to the value of TileNum (" + TOSTR(p_tile_group->num_tiles_parsed) + ") at the point that tile_group_obu is invoked."));
             return PARSER_WRONG_STATE;
         }
         p_tile_group->tg_end = Parser::ReadBits(p_stream, offset, tile_bits);
         if (p_tile_group->tg_end < p_tile_group->tg_start) {
-            ERR("It is a requirement of bitstream conformance that the value of tg_end (" + TOSTR(p_tile_group->tg_end) + ") is greater than or equal to tg_start (" + TOSTR(p_tile_group->tg_start) + ").");
+            logger_.ErrorLog(MakeMsg("It is a requirement of bitstream conformance that the value of tg_end (" + TOSTR(p_tile_group->tg_end) + ") is greater than or equal to tg_start (" + TOSTR(p_tile_group->tg_start) + ")."));
             return PARSER_WRONG_STATE;
         }
     }
@@ -1344,7 +1344,7 @@ ParserResult Av1VideoParser::ParseTileGroupObu(uint8_t *p_stream, size_t size) {
     tg_size -= header_bytes;
     for (int tile_num = p_tile_group->tg_start; tile_num <= p_tile_group->tg_end; tile_num++) {
         if (tile_cols == 0) {
-            ERR("Tile columns is 0.");
+            logger_.ErrorLog(MakeMsg("Tile columns is 0."));
             return PARSER_WRONG_STATE;
         }
         p_tile_group->tile_data_info[tile_num].tile_row = tile_num / tile_cols;
@@ -2442,7 +2442,7 @@ ParserResult Av1VideoParser::FilmGrainParams(const uint8_t *p_stream, size_t &of
     for (i = 0; i < p_frame_header->film_grain_params.num_y_points; i++) {
         p_frame_header->film_grain_params.point_y_value[i] = Parser::ReadBits(p_stream, offset, 8);
         if (i > 0 && p_frame_header->film_grain_params.point_y_value[i] <= p_frame_header->film_grain_params.point_y_value[i - 1]) {
-            ERR("point_y_value["+ TOSTR(i) + "] (" + TOSTR(p_frame_header->film_grain_params.point_y_value[i]) + ") should be greater than point_y_value[" + TOSTR(i - 1) + "] (" + TOSTR(p_frame_header->film_grain_params.point_y_value[i - 1]) + ")");
+            logger_.ErrorLog(MakeMsg("point_y_value["+ TOSTR(i) + "] (" + TOSTR(p_frame_header->film_grain_params.point_y_value[i]) + ") should be greater than point_y_value[" + TOSTR(i - 1) + "] (" + TOSTR(p_frame_header->film_grain_params.point_y_value[i - 1]) + ")"));
             return PARSER_INVALID_ARG;
         }
         p_frame_header->film_grain_params.point_y_scaling[i] = Parser::ReadBits(p_stream, offset, 8);
@@ -2463,7 +2463,7 @@ ParserResult Av1VideoParser::FilmGrainParams(const uint8_t *p_stream, size_t &of
         for (i = 0; i < p_frame_header->film_grain_params.num_cb_points; i++) {
             p_frame_header->film_grain_params.point_cb_value[i] = Parser::ReadBits(p_stream, offset, 8);
             if (i > 0 && p_frame_header->film_grain_params.point_cb_value[i] <= p_frame_header->film_grain_params.point_cb_value[i - 1]) {
-                ERR("point_cb_value["+ TOSTR(i) + "] (" + TOSTR(p_frame_header->film_grain_params.point_cb_value[i]) + ") should be greater than point_cb_value[" + TOSTR(i - 1) + "] (" + TOSTR(p_frame_header->film_grain_params.point_cb_value[i - 1]) + ")");
+                logger_.ErrorLog(MakeMsg("point_cb_value["+ TOSTR(i) + "] (" + TOSTR(p_frame_header->film_grain_params.point_cb_value[i]) + ") should be greater than point_cb_value[" + TOSTR(i - 1) + "] (" + TOSTR(p_frame_header->film_grain_params.point_cb_value[i - 1]) + ")"));
                 return PARSER_INVALID_ARG;
             }
             p_frame_header->film_grain_params.point_cb_scaling[i] = Parser::ReadBits(p_stream, offset, 8);
@@ -2472,11 +2472,11 @@ ParserResult Av1VideoParser::FilmGrainParams(const uint8_t *p_stream, size_t &of
         CHECK_ALLOWED_MAX("num_cr_points", p_frame_header->film_grain_params.num_cr_points, 10);
         if (p_seq_header->color_config.subsampling_x == 1 && p_seq_header->color_config.subsampling_y == 1) {
             if (p_frame_header->film_grain_params.num_cb_points == 0 && p_frame_header->film_grain_params.num_cr_points != 0) {
-                ERR("If subsampling_x is equal to 1 and subsampling_y is equal to 1 and num_cb_points is equal to 0, it is a requirement of bitstream conformance that num_cr_points is equal to 0.");
+                logger_.ErrorLog(MakeMsg("If subsampling_x is equal to 1 and subsampling_y is equal to 1 and num_cb_points is equal to 0, it is a requirement of bitstream conformance that num_cr_points is equal to 0."));
                 return PARSER_WRONG_STATE;
             }
             if (p_frame_header->film_grain_params.num_cb_points != 0 && p_frame_header->film_grain_params.num_cr_points == 0) {
-                ERR("If subsampling_x is equal to 1 and subsampling_y is equal to 1 and num_cb_points is not equal to 0, it is a requirement of bitstream conformance that num_cr_points is not equal to 0.");
+                logger_.ErrorLog(MakeMsg("If subsampling_x is equal to 1 and subsampling_y is equal to 1 and num_cb_points is not equal to 0, it is a requirement of bitstream conformance that num_cr_points is not equal to 0."));
                 return PARSER_WRONG_STATE;
             }
         }
@@ -2484,7 +2484,7 @@ ParserResult Av1VideoParser::FilmGrainParams(const uint8_t *p_stream, size_t &of
         {
             p_frame_header->film_grain_params.point_cr_value[i] = Parser::ReadBits(p_stream, offset, 8);
             if (i > 0 && p_frame_header->film_grain_params.point_cr_value[i] <= p_frame_header->film_grain_params.point_cr_value[i - 1]) {
-                ERR("point_cr_value["+ TOSTR(i) + "] (" + TOSTR(p_frame_header->film_grain_params.point_cr_value[i]) + ") should be greater than point_cr_value[" + TOSTR(i - 1) + "] (" + TOSTR(p_frame_header->film_grain_params.point_cr_value[i - 1]) + ")");
+                logger_.ErrorLog(MakeMsg("point_cr_value["+ TOSTR(i) + "] (" + TOSTR(p_frame_header->film_grain_params.point_cr_value[i]) + ") should be greater than point_cr_value[" + TOSTR(i - 1) + "] (" + TOSTR(p_frame_header->film_grain_params.point_cr_value[i - 1]) + ")"));
                 return PARSER_INVALID_ARG;
             }
             p_frame_header->film_grain_params.point_cr_scaling[i] = Parser::ReadBits(p_stream, offset, 8);

--- a/src/parser/avc_parser.cpp
+++ b/src/parser/avc_parser.cpp
@@ -65,7 +65,7 @@ rocDecStatus AvcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     if (p_data->payload && p_data->payload_size) {
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
-            ERR(STR("Parser failed!"));
+            logger_.ErrorLog(MakeMsg(STR("Parser failed!")));
             return ROCDEC_RUNTIME_ERROR;
         }
 
@@ -99,7 +99,7 @@ rocDecStatus AvcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
 
         // Decode the picture
         if (SendPicForDecode() != PARSER_OK) {
-            ERR(STR("Failed to decode!"));
+            logger_.ErrorLog(MakeMsg(STR("Failed to decode!")));
             return ROCDEC_RUNTIME_ERROR;
         }
 
@@ -149,7 +149,7 @@ ParserResult AvcVideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
     do {
         ret = GetNalUnit();
         if (ret == PARSER_NOT_FOUND) {
-            ERR(STR("Error: no start code found in the frame data."));
+            logger_.ErrorLog(MakeMsg(STR("Error: no start code found in the frame data.")));
             return ret;
         }
 
@@ -164,7 +164,7 @@ ParserResult AvcVideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                     memcpy(rbsp_buf_, (pic_data_buffer_ptr_ + curr_start_code_offset_ + 4), ebsp_size);
                     rbsp_size_ = EbspToRbsp(rbsp_buf_, 0, ebsp_size);
                     if ((ret2 = ParseSps(rbsp_buf_, rbsp_size_)) != PARSER_OK) {
-                        ERR("Error occurred in SPS parsing. This SPS NAL unit is skipped.");
+                        logger_.ErrorLog(MakeMsg("Error occurred in SPS parsing. This SPS NAL unit is skipped."));
                     }
                     break;
                 }
@@ -173,7 +173,7 @@ ParserResult AvcVideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                     memcpy(rbsp_buf_, (pic_data_buffer_ptr_ + curr_start_code_offset_ + 4), ebsp_size);
                     rbsp_size_ = EbspToRbsp(rbsp_buf_, 0, ebsp_size);
                     if ((ret2 = ParsePps(rbsp_buf_, rbsp_size_)) != PARSER_OK) {
-                        ERR("Error occurred in PPS parsing. This PPS NAL unit is skipped.");
+                        logger_.ErrorLog(MakeMsg("Error occurred in PPS parsing. This PPS NAL unit is skipped."));
                     }
                     break;
                 }
@@ -195,7 +195,7 @@ ParserResult AvcVideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                     rbsp_size_ = EbspToRbsp(rbsp_buf_, 0, ebsp_size);
                     AvcSliceHeader *p_slice_header = &slice_info_list_[num_slices_].slice_header;
                     if ((ret2 = ParseSliceHeader(rbsp_buf_, rbsp_size_, p_slice_header)) != PARSER_OK) {
-                        ERR("Error occurred in slice header parsing. This slice NAL unit is skipped.");
+                        logger_.ErrorLog(MakeMsg("Error occurred in slice header parsing. This slice NAL unit is skipped."));
                         break;      // ignore and continue to next nal_unit
                     }
                     slice_info_list_[num_slices_].slice_data_offset = curr_start_code_offset_;
@@ -243,7 +243,7 @@ ParserResult AvcVideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
 
                     // Reference picture lists construction (8.2.4)
                     if (SetupReflist(&slice_info_list_[num_slices_]) != PARSER_OK) {
-                        ERR("Error occurred in SetupReflist(). Ignore and continue.");
+                        logger_.ErrorLog(MakeMsg("Error occurred in SetupReflist(). Ignore and continue."));
                     }
 
                     if (num_slices_ == 0) {
@@ -343,7 +343,7 @@ ParserResult AvcVideoParser::NotifyNewSps(AvcSeqParameterSet *p_sps) {
             break;
         }
         default:
-            ERR(STR("Error: Sequence Callback function - Chroma Format is not supported"));
+            logger_.ErrorLog(MakeMsg(STR("Error: Sequence Callback function - Chroma Format is not supported")));
             return PARSER_FAIL;
     }
     int chroma_array_type = p_sps->separate_colour_plane_flag ? 0 : p_sps->chroma_format_idc;
@@ -411,7 +411,7 @@ ParserResult AvcVideoParser::NotifyNewSps(AvcSeqParameterSet *p_sps) {
 
     // callback function with RocdecVideoFormat params filled out
     if (pfn_sequence_cb_(parser_params_.user_data, &video_format_params_) == 0) {
-        ERR("Sequence callback function failed.");
+        logger_.ErrorLog(MakeMsg("Sequence callback function failed."));
         return PARSER_FAIL;
     } else {
         return PARSER_OK;
@@ -716,7 +716,7 @@ ParserResult AvcVideoParser::SendPicForDecode() {
 #endif // DBGINFO
 
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
-        ERR("Decode error occurred.");
+        logger_.ErrorLog(MakeMsg("Decode error occurred."));
         return PARSER_FAIL;
     } else {
         return PARSER_OK;
@@ -1036,7 +1036,7 @@ ParserResult AvcVideoParser::ParsePps(uint8_t *p_stream, size_t stream_size_in_b
     uint32_t seq_parameter_set_id = Parser::ExpGolomb::ReadUe(p_stream, offset);
     CHECK_ALLOWED_RANGE("seq_parameter_set_id", seq_parameter_set_id, 0, 31);
     if (sps_list_[seq_parameter_set_id].is_received == 0) {
-        ERR("Empty SPS is referred.");
+        logger_.ErrorLog(MakeMsg("Empty SPS is referred."));
         return PARSER_WRONG_STATE;
     }
     p_sps = &sps_list_[seq_parameter_set_id];
@@ -1051,7 +1051,7 @@ ParserResult AvcVideoParser::ParsePps(uint8_t *p_stream, size_t stream_size_in_b
     p_pps->num_slice_groups_minus1 = Parser::ExpGolomb::ReadUe(p_stream, offset);
     if (p_pps->num_slice_groups_minus1 > 0) {
         // Note: VCN supports High Profile only (num_slice_groups_minus1 = 0)
-        ERR("Multiple slice groups are not supported");
+        logger_.ErrorLog(MakeMsg("Multiple slice groups are not supported"));
         return PARSER_NOT_SUPPORTED;
     }
 
@@ -1224,7 +1224,7 @@ ParserResult AvcVideoParser::ParseSliceHeader(uint8_t *p_stream, size_t stream_s
     int32_t active_pps_id = Parser::ExpGolomb::ReadUe(p_stream, offset);
     CHECK_ALLOWED_RANGE("pic_parameter_set_id", active_pps_id, 0, 255);
     if (pps_list_[active_pps_id].is_received == 0) {
-        ERR("Empty PPS is referred.");
+        logger_.ErrorLog(MakeMsg("Empty PPS is referred."));
         return PARSER_WRONG_STATE;
     }
     active_pps_id_ = active_pps_id;
@@ -1233,14 +1233,14 @@ ParserResult AvcVideoParser::ParseSliceHeader(uint8_t *p_stream, size_t stream_s
 
     int32_t active_sps_id = p_pps->seq_parameter_set_id;
     if (sps_list_[active_sps_id].is_received == 0) {
-        ERR("Empty SPS is referred.");
+        logger_.ErrorLog(MakeMsg("Empty SPS is referred."));
         return PARSER_WRONG_STATE;
     }
     if (active_sps_id_ != p_pps->seq_parameter_set_id) {
         active_sps_id_ = p_pps->seq_parameter_set_id;
         p_sps = &sps_list_[active_sps_id_];
         if ( p_sps->is_received == 0) {
-            ERR("Empty SPS is referred.");
+            logger_.ErrorLog(MakeMsg("Empty SPS is referred."));
             return PARSER_WRONG_STATE;
         }
         new_seq_activated_ = true;  // Note: clear this flag after the actions are taken.
@@ -1922,7 +1922,7 @@ ParserResult AvcVideoParser::DecodeFrameNumGaps() {
     if (slice_nal_unit_header_.nal_unit_type == kAvcNalTypeSlice_IDR) {
         prev_ref_frame_num_ = 0;
     } else if ((p_slice_header->frame_num != prev_ref_frame_num_) && (p_slice_header->frame_num != ((prev_ref_frame_num_ + 1) % max_frame_num))) {
-        ERR("Support for gaps in frame_num is currently disabled.\n");
+        logger_.ErrorLog(MakeMsg("Support for gaps in frame_num is currently disabled."));
         return PARSER_NOT_SUPPORTED;
         #if 0
         int unused_short_term_frame_num = (prev_ref_frame_num_ + 1) % max_frame_num;
@@ -2061,7 +2061,7 @@ ParserResult AvcVideoParser::DecodeFrameNumGaps() {
                 if (min_index < dpb_buffer_.dpb_size) {
                     dpb_buffer_.frame_buffer_list[min_index].is_reference = kUnusedForReference;
                 } else {
-                    ERR("Could not find any short term ref picture.");
+                    logger_.ErrorLog(MakeMsg("Could not find any short term ref picture."));
                     return PARSER_FAIL;
                 }
                 dpb_buffer_.num_short_term--;
@@ -2086,7 +2086,7 @@ ParserResult AvcVideoParser::DecodeFrameNumGaps() {
                 dpb_buffer_.dpb_fullness++;
                 dpb_buffer_.num_short_term++;
             } else {
-                ERR("Could not find any free frame buffer in DPB.");
+                logger_.ErrorLog(MakeMsg("Could not find any free frame buffer in DPB."));
                 return PARSER_FAIL;
             }
 
@@ -2627,7 +2627,7 @@ ParserResult AvcVideoParser::ModifiyRefList(AvcPicture *ref_pic_list_x, AvcListM
                 }
             }
             if (i == num_short_term_pics) {
-                ERR("Could not find a short-term reference with the modified pic num.");
+                logger_.ErrorLog(MakeMsg("Could not find a short-term reference with the modified pic num."));
                 return PARSER_OUT_OF_RANGE;
             }
             ref_pic_list_mod[ref_idx_lx] = ref_pic_list_x[i];
@@ -2654,7 +2654,7 @@ ParserResult AvcVideoParser::ModifiyRefList(AvcPicture *ref_pic_list_x, AvcListM
                 }
             }
             if (i == num_short_term_pics + num_long_term_pics) {
-                ERR("Could not find long-term reference with the modified long term pic num.");
+                logger_.ErrorLog(MakeMsg("Could not find long-term reference with the modified long term pic num."));
                 return PARSER_OUT_OF_RANGE;
             }
             ref_pic_list_mod[ref_idx_lx] = ref_pic_list_x[i];
@@ -2701,7 +2701,7 @@ ParserResult AvcVideoParser::FindFreeInDecBufPool() {
             }
         }
         if (dec_buf_index == dec_buf_pool_size_) {
-            ERR("Could not find a free buffer in decode buffer pool.");
+            logger_.ErrorLog(MakeMsg("Could not find a free buffer in decode buffer pool."));
             return PARSER_NOT_FOUND;
         }
 
@@ -2740,7 +2740,7 @@ ParserResult AvcVideoParser::FindFreeBufInDpb() {
                 curr_pic_.use_status = kBottomFieldUsedForDecode;
             }
         } else {
-            ERR("Could not find any free frame buffer in DPB.");
+            logger_.ErrorLog(MakeMsg("Could not find any free frame buffer in DPB."));
             return PARSER_FAIL;
         }
 
@@ -3047,7 +3047,7 @@ ParserResult AvcVideoParser::MarkDecodedRefPics() {
                     break;
 
                     default: {
-                        ERR("Invalid memory management control operation!");
+                        logger_.ErrorLog(MakeMsg("Invalid memory management control operation!"));
                         return PARSER_INVALID_ARG;
                     }
                 }
@@ -3079,7 +3079,7 @@ ParserResult AvcVideoParser::MarkDecodedRefPics() {
                     dpb_buffer_.field_pic_list[min_index * 2].is_reference = kUnusedForReference;
                     dpb_buffer_.field_pic_list[min_index * 2 + 1].is_reference = kUnusedForReference;
                 } else {
-                    ERR("Could not find any short term ref picture.");
+                    logger_.ErrorLog(MakeMsg("Could not find any short term ref picture."));
                     return PARSER_FAIL;
                 }
                 dpb_buffer_.num_short_term--;
@@ -3114,7 +3114,7 @@ ParserResult AvcVideoParser::BumpPicFromDpb() {
         }
     }
     if (min_poc_pic_idx_no_ref >= dpb_buffer_.dpb_size) {
-        ERR("Error! Could not find a non-reference buffer to bump.");
+        logger_.ErrorLog(MakeMsg("Error! Could not find a non-reference buffer to bump."));
         return PARSER_OUT_OF_RANGE;
     }
 
@@ -3126,7 +3126,7 @@ ParserResult AvcVideoParser::BumpPicFromDpb() {
             // Insert into output/display picture list
             if (pfn_display_picture_cb_) {
                 if (num_output_pics_ >= dec_buf_pool_size_) {
-                    ERR("Error! Decode buffer pool overflow!");
+                    logger_.ErrorLog(MakeMsg("Error! Decode buffer pool overflow!"));
                     return PARSER_OUT_OF_RANGE;
                 } else {
                     output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx_ref].dec_buf_idx;
@@ -3154,7 +3154,7 @@ ParserResult AvcVideoParser::BumpPicFromDpb() {
         // Insert into output/display picture list
         if (pfn_display_picture_cb_) {
             if (num_output_pics_ >= dec_buf_pool_size_) {
-                ERR("Error! Decode buffer pool overflow!");
+                logger_.ErrorLog(MakeMsg("Error! Decode buffer pool overflow!"));
                 return PARSER_OUT_OF_RANGE;
             } else {
                 output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx_no_ref].dec_buf_idx;
@@ -3237,7 +3237,7 @@ ParserResult AvcVideoParser::InsertCurrPicIntoDpb() {
         decode_buffer_pool_[curr_pic_.dec_buf_idx].pic_order_cnt = curr_pic_.pic_order_cnt;
         decode_buffer_pool_[curr_pic_.dec_buf_idx].pts = curr_pts_;
     } else {
-        ERR("Could not find the reserved frame buffer for the current picture in DPB.");
+        logger_.ErrorLog(MakeMsg("Could not find the reserved frame buffer for the current picture in DPB."));
         return PARSER_FAIL;
     }
 

--- a/src/parser/hevc_parser.cpp
+++ b/src/parser/hevc_parser.cpp
@@ -59,7 +59,7 @@ rocDecStatus HevcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     if (p_data->payload && p_data->payload_size) {
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
-            ERR(STR("Parser failed!"));
+            logger_.ErrorLog(MakeMsg(STR("Parser failed!")));
             return ROCDEC_RUNTIME_ERROR;
         }
 
@@ -83,7 +83,7 @@ rocDecStatus HevcVideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
 
         // Decode the picture
         if (SendPicForDecode() != PARSER_OK) {
-            ERR(STR("Failed to decode!"));
+            logger_.ErrorLog(MakeMsg(STR("Failed to decode!")));
             return ROCDEC_RUNTIME_ERROR;
         }
 
@@ -148,7 +148,7 @@ int HevcVideoParser::FillSeqCallbackFn(HevcSeqParamSet* sps_data) {
             break;
         }
         default:
-            ERR(STR("Error: Sequence Callback function - Chroma Format is not supported"));
+            logger_.ErrorLog(MakeMsg(STR("Error: Sequence Callback function - Chroma Format is not supported")));
             return PARSER_FAIL;
     }
     if(sps_data->conformance_window_flag) {
@@ -207,7 +207,7 @@ int HevcVideoParser::FillSeqCallbackFn(HevcSeqParamSet* sps_data) {
 
     // callback function with RocdecVideoFormat params filled out
     if (pfn_sequence_cb_(parser_params_.user_data, &video_format_params_) == 0) {
-        ERR("Sequence callback function failed.");
+        logger_.ErrorLog(MakeMsg("Sequence callback function failed."));
         return PARSER_FAIL;
     } else {
         return PARSER_OK;
@@ -412,7 +412,7 @@ int HevcVideoParser::SendPicForDecode() {
                     }
                 }
                 if (j == 15) {
-                    ERR("Could not find matching pic in ref_frames list. The slice type is P/B, and the idx from the ref_pic_list_0_ is: " + TOSTR(idx));
+                    logger_.ErrorLog(MakeMsg("Could not find matching pic in ref_frames list. The slice type is P/B, and the idx from the ref_pic_list_0_ is: " + TOSTR(idx)));
                     return PARSER_FAIL;
                 } else {
                     slice_params_ptr->ref_pic_list[0][i] = j;
@@ -429,7 +429,7 @@ int HevcVideoParser::SendPicForDecode() {
                         }
                     }
                     if (j == 15) {
-                        ERR("Could not find matching pic in ref_frames list. The slice type is B, and the idx from the ref_pic_list_1_ is: " + TOSTR(idx));
+                        logger_.ErrorLog(MakeMsg("Could not find matching pic in ref_frames list. The slice type is B, and the idx from the ref_pic_list_1_ is: " + TOSTR(idx)));
                         return PARSER_FAIL;
                     } else {
                         slice_params_ptr->ref_pic_list[1][i] = j;
@@ -520,7 +520,7 @@ int HevcVideoParser::SendPicForDecode() {
 #endif // DBGINFO
 
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
-        ERR("Decode error occurred.");
+        logger_.ErrorLog(MakeMsg("Decode error occurred."));
         return PARSER_FAIL;
     } else {
         return PARSER_OK;
@@ -545,7 +545,7 @@ ParserResult HevcVideoParser::ParsePictureData(const uint8_t* p_stream, uint32_t
     do {
         ret = GetNalUnit();
         if (ret == PARSER_NOT_FOUND) {
-            ERR(STR("Error: no start code found in the frame data."));
+            logger_.ErrorLog(MakeMsg(STR("Error: no start code found in the frame data.")));
             return ret;
         }
         // Parse the NAL unit
@@ -1254,7 +1254,7 @@ ParserResult HevcVideoParser::ParseVps(uint8_t *nalu, size_t size) {
     p_vps->vps_temporal_id_nesting_flag = Parser::GetBit(nalu, offset);
     p_vps->vps_reserved_0xffff_16bits = Parser::ReadBits(nalu, offset, 16);
     if (p_vps->vps_reserved_0xffff_16bits != 0xFFFF) {
-        ERR("vps_reserved_0xffff_16bits is not equal to 0xFFFF.");
+        logger_.ErrorLog(MakeMsg("vps_reserved_0xffff_16bits is not equal to 0xFFFF."));
         return PARSER_INVALID_ARG;
     }
     ParsePtl(&p_vps->profile_tier_level, true, p_vps->vps_max_sub_layers_minus1, nalu, size, offset);
@@ -1374,12 +1374,12 @@ ParserResult HevcVideoParser::ParseSps(uint8_t *nalu, size_t size) {
     }
     sps_ptr->bit_depth_luma_minus8 = Parser::ExpGolomb::ReadUe(nalu, offset);
     if ( sps_ptr->bit_depth_luma_minus8 != 0 && sps_ptr->bit_depth_luma_minus8 != 2) {
-        ERR("bit_depth_luma_minus8 = " + TOSTR(sps_ptr->bit_depth_luma_minus8) + " is not supported");
+        logger_.ErrorLog(MakeMsg("bit_depth_luma_minus8 = " + TOSTR(sps_ptr->bit_depth_luma_minus8) + " is not supported"));
         return PARSER_OUT_OF_RANGE;
     }
     sps_ptr->bit_depth_chroma_minus8 = Parser::ExpGolomb::ReadUe(nalu, offset);
     if ( sps_ptr->bit_depth_chroma_minus8 != 0 && sps_ptr->bit_depth_chroma_minus8 != 2) {
-        ERR("bit_depth_chroma_minus8 = " + TOSTR(sps_ptr->bit_depth_chroma_minus8) + " is not supported");
+        logger_.ErrorLog(MakeMsg("bit_depth_chroma_minus8 = " + TOSTR(sps_ptr->bit_depth_chroma_minus8) + " is not supported"));
         return PARSER_OUT_OF_RANGE;
     }
     sps_ptr->log2_max_pic_order_cnt_lsb_minus4 = Parser::ExpGolomb::ReadUe(nalu, offset);
@@ -1444,7 +1444,7 @@ ParserResult HevcVideoParser::ParseSps(uint8_t *nalu, size_t size) {
         sps_ptr->log2_min_pcm_luma_coding_block_size_minus3 = Parser::ExpGolomb::ReadUe(nalu, offset);
         //CHECK_ALLOWED_RANGE("log2_min_pcm_luma_coding_block_size", sps_ptr->log2_min_pcm_luma_coding_block_size_minus3 + 3, std::min(min_cb_log2_size_y, 5), std::min(ctb_log2_size_y_, 5));
         if ((sps_ptr->log2_min_pcm_luma_coding_block_size_minus3 + 3) < std::min(min_cb_log2_size_y, 5) || (sps_ptr->log2_min_pcm_luma_coding_block_size_minus3 + 3) > std::min(ctb_log2_size_y_, 5)) {
-            ERR("log2_min_pcm_luma_coding_block_size = " + TOSTR(sps_ptr->log2_min_pcm_luma_coding_block_size_minus3 + 3) + " not in allowd range: " + TOSTR(std::min(min_cb_log2_size_y, 5)) + ", " + TOSTR(std::min(ctb_log2_size_y_, 5)));
+            logger_.ErrorLog(MakeMsg("log2_min_pcm_luma_coding_block_size = " + TOSTR(sps_ptr->log2_min_pcm_luma_coding_block_size_minus3 + 3) + " not in allowd range: " + TOSTR(std::min(min_cb_log2_size_y, 5)) + ", " + TOSTR(std::min(ctb_log2_size_y_, 5))));
         }
         sps_ptr->log2_diff_max_min_pcm_luma_coding_block_size = Parser::ExpGolomb::ReadUe(nalu, offset);
         CHECK_ALLOWED_MAX("log2_max_ipcm_cb_size_y", sps_ptr->log2_diff_max_min_pcm_luma_coding_block_size + sps_ptr->log2_min_pcm_luma_coding_block_size_minus3 + 3, std::min(ctb_log2_size_y_, 5));
@@ -1650,7 +1650,7 @@ ParserResult HevcVideoParser::ParseSliceHeader(uint8_t *nalu, size_t size, HevcS
     int32_t active_pps_id = Parser::ExpGolomb::ReadUe(nalu, offset);
     CHECK_ALLOWED_MAX("active_pps_id", active_pps_id, (MAX_PPS_COUNT - 1));
     if (pps_list_[active_pps_id].is_received == 0) {
-        ERR("Empty PPS is referred.");
+        logger_.ErrorLog(MakeMsg("Empty PPS is referred."));
         return PARSER_WRONG_STATE;
     }
     active_pps_id_ = active_pps_id;
@@ -1659,7 +1659,7 @@ ParserResult HevcVideoParser::ParseSliceHeader(uint8_t *nalu, size_t size, HevcS
 
     int32_t active_sps_id = pps_ptr->pps_seq_parameter_set_id;
     if (sps_list_[active_sps_id].is_received == 0) {
-        ERR("Empty SPS is referred.");
+        logger_.ErrorLog(MakeMsg("Empty SPS is referred."));
         return PARSER_WRONG_STATE;
     }
     if (active_sps_id_ != active_sps_id) {
@@ -1671,7 +1671,7 @@ ParserResult HevcVideoParser::ParseSliceHeader(uint8_t *nalu, size_t size, HevcS
 
     int active_vps_id = sps_ptr->sps_video_parameter_set_id;
     if (vps_list_[active_vps_id].is_received == 0) {
-        ERR("Empty VPS is referred.");
+        logger_.ErrorLog(MakeMsg("Empty VPS is referred."));
         return PARSER_WRONG_STATE;
     }
     active_vps_id_ = active_vps_id;
@@ -2345,7 +2345,7 @@ int HevcVideoParser::MarkOutputPictures() {
                 if (dpb_buffer_.dpb_fullness > 0) {
                     dpb_buffer_.dpb_fullness--;
                 } else {
-                    ERR("Invalid DPB buffer fullness:" + TOSTR(dpb_buffer_.dpb_fullness));
+                    logger_.ErrorLog(MakeMsg("Invalid DPB buffer fullness:" + TOSTR(dpb_buffer_.dpb_fullness)));
                     return PARSER_FAIL;
                 }
             }
@@ -2384,7 +2384,7 @@ ParserResult HevcVideoParser::FindFreeInDecBufPool() {
         }
     }
     if (dec_buf_index == dec_buf_pool_size_) {
-        ERR("Could not find a free buffer in decode buffer pool.");
+        logger_.ErrorLog(MakeMsg("Could not find a free buffer in decode buffer pool."));
         return PARSER_NOT_FOUND;
     }
     curr_pic_info_.dec_buf_idx = dec_buf_index;
@@ -2406,7 +2406,7 @@ ParserResult HevcVideoParser::FindFreeInDpbAndMark() {
         }
     }
     if (index == dpb_buffer_.dpb_size) {
-        ERR("Error! DPB buffer overflow! Fullness = " + TOSTR(dpb_buffer_.dpb_fullness));
+        logger_.ErrorLog(MakeMsg("Error! DPB buffer overflow! Fullness = " + TOSTR(dpb_buffer_.dpb_fullness)));
         return PARSER_NOT_FOUND;
     }
 
@@ -2487,7 +2487,7 @@ int HevcVideoParser::BumpPicFromDpb() {
     // Insert into output/display picture list
     if (pfn_display_picture_cb_) {
         if (num_output_pics_ >= dec_buf_pool_size_) {
-            ERR("Error! Decode buffer pool overflow!");
+            logger_.ErrorLog(MakeMsg("Error! Decode buffer pool overflow!"));
             return PARSER_OUT_OF_RANGE;
         } else {
             output_pic_list_[num_output_pics_] = dpb_buffer_.frame_buffer_list[min_poc_pic_idx].dec_buf_idx;

--- a/src/parser/roc_video_parser.cpp
+++ b/src/parser/roc_video_parser.cpp
@@ -56,7 +56,7 @@ RocVideoParser::~RocVideoParser() {
  */
 rocDecStatus RocVideoParser::Initialize(RocdecParserParams *pParams) {
     if(pParams == nullptr) {
-        ERR(STR("Parser parameters are not set for the parser"));
+        logger_.CriticalLog(STR("Parser parameters are not set for the parser"));
         return ROCDEC_NOT_INITIALIZED;
     }
     // Initialize callback function pointers

--- a/src/parser/roc_video_parser.h
+++ b/src/parser/roc_video_parser.h
@@ -82,14 +82,14 @@ typedef struct {
 
 #define CHECK_ALLOWED_RANGE(str, val, min, max) { \
     if (val < min || val > max) { \
-        ERR (STR(str) + " value not in valid range: " + TOSTR(val) + ", allowed (min,max): " + TOSTR(min) + "," + TOSTR(max));\
+        logger_.ErrorLog(MakeMsg(STR(str) + " value not in valid range: " + TOSTR(val) + ", allowed (min,max): " + TOSTR(min) + "," + TOSTR(max)));\
         return PARSER_OUT_OF_RANGE; \
     } \
 }
 
 #define CHECK_ALLOWED_MAX(str, val, max) { \
     if (val > max) { \
-        ERR (STR(str) +  " value greater than maximum allowed value: " + TOSTR(val) + ", max: " + TOSTR(max));\
+        logger_.ErrorLog(MakeMsg(STR(str) +  " value greater than maximum allowed value: " + TOSTR(val) + ", max: " + TOSTR(max))); \
         return PARSER_OUT_OF_RANGE; \
     } \
 }
@@ -110,7 +110,7 @@ class RocVideoParser {
 public:
     RocVideoParser();    // default constructor
     virtual ~RocVideoParser();
-    RocVideoParser(RocdecParserParams *pParams) : parser_params_(*pParams) {};
+    RocVideoParser(RocdecParserParams *pParams, u_int log_level) : parser_params_(*pParams) {logger_.SetLogLevel(log_level);};
     virtual void SetParserParams(RocdecParserParams *pParams) { parser_params_ = *pParams; };
     RocdecParserParams *GetParserParams() {return &parser_params_;};
     virtual rocDecStatus Initialize(RocdecParserParams *pParams);
@@ -189,6 +189,8 @@ protected:
     uint8_t             *sei_payload_buf_;  // buffer to store SEI playload. Allocated at run time.
     uint32_t            sei_payload_buf_size_;
     uint32_t            sei_payload_size_;  // total SEI payload size of the current frame
+
+    RocDecLogger logger_;
 
     /*! \brief Function to check the initially set (by decoder) decode buffer pool size and adjust if needed
      *  \param dpb_size The DPB buffer size of the current sequence

--- a/src/parser/rocparser_api.cpp
+++ b/src/parser/rocparser_api.cpp
@@ -38,7 +38,7 @@ rocDecCreateVideoParser(RocdecVideoParser *parser_handle, RocdecParserParams *pa
         parser_params->codec_type != rocDecVideoCodec_AVC &&
         parser_params->codec_type != rocDecVideoCodec_VP9 &&
         parser_params->codec_type != rocDecVideoCodec_AV1) {
-        ERR("The current version of rocDecode officially supports only the H.265 (HEVC), H.264 (AVC) and AV1 codecs.");
+        RocDecLogger::AlwaysLog("Error: The current version of rocDecode officially supports only the H.265 (HEVC), H.264 (AVC), AV1 and VP9 codecs.");
         return ROCDEC_NOT_IMPLEMENTED;
     }
 
@@ -47,7 +47,7 @@ rocDecCreateVideoParser(RocdecVideoParser *parser_handle, RocdecParserParams *pa
         handle = new RocParserHandle(parser_params);
     } 
     catch(const std::exception& e) {
-        ERR( STR("Failed to init the rocDecode handle, ") + STR(e.what()))
+        RocDecLogger::AlwaysLog(STR("Error: Failed to init the rocDecode handle, ") + STR(e.what()));
         return ROCDEC_RUNTIME_ERROR;
     }
     *parser_handle = handle;
@@ -76,7 +76,7 @@ rocDecParseVideoData(RocdecVideoParser parser_handle, RocdecSourceDataPacket *pa
     }
     catch(const std::exception& e) {
         roc_parser_handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;  
@@ -100,7 +100,7 @@ rocDecDestroyVideoParser(RocdecVideoParser parser_handle) {
     catch(const std::exception& e) {
         roc_parser_handle->CaptureError(e.what());
         delete roc_parser_handle;
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     delete roc_parser_handle;

--- a/src/parser/vp9_parser.cpp
+++ b/src/parser/vp9_parser.cpp
@@ -64,7 +64,7 @@ rocDecStatus Vp9VideoParser::ParseVideoData(RocdecSourceDataPacket *p_data) {
     if (p_data->payload && p_data->payload_size) {
         curr_pts_ = p_data->pts;
         if (ParsePictureData(p_data->payload, p_data->payload_size) != PARSER_OK) {
-            ERR("Error occurred in ParsePictureData().");
+            logger_.ErrorLog(MakeMsg("Error occurred in ParsePictureData()."));
             return ROCDEC_RUNTIME_ERROR;
         }
     } else if (!(p_data->flags & ROCDEC_PKT_ENDOFSTREAM)) {
@@ -87,7 +87,7 @@ ParserResult Vp9VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
     uint8_t *pic_data_ptr = const_cast<uint8_t*>(p_stream);
     for (int frame_index = 0; frame_index < num_frames_in_chunck_; frame_index++) {
         if ((ret = ParseUncompressedHeader(pic_data_ptr, frame_sizes_[frame_index])) != PARSER_OK) {
-            ERR("Error occurred in ParseUncompressedHeader(). Skip this picture.");
+            logger_.ErrorLog(MakeMsg("Error occurred in ParseUncompressedHeader(). Skip this picture."));
         } else {
             // Init Roc decoder for the first time or reconfigure the existing decoder
             if (new_seq_activated_) {
@@ -103,7 +103,7 @@ ParserResult Vp9VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
             if (uncompressed_header_.show_existing_frame) {
                 int disp_idx = dpb_buffer_.virtual_buffer_index[uncompressed_header_.frame_to_show_map_idx];
                 if (disp_idx == INVALID_INDEX) {
-                    ERR("Invalid existing frame index to show.");
+                    logger_.ErrorLog(MakeMsg("Invalid existing frame index to show."));
                     return PARSER_INVALID_ARG;
                 }
                 if (pfn_display_picture_cb_) {
@@ -115,7 +115,7 @@ ParserResult Vp9VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                         output_pic_list_[num_output_pics_] = disp_idx;
                         num_output_pics_++;
                     } else {
-                        ERR("Display list size larger than decode buffer pool size!");
+                        logger_.ErrorLog(MakeMsg("Display list size larger than decode buffer pool size!"));
                         return PARSER_OUT_OF_RANGE;
                     }
                 }
@@ -134,7 +134,7 @@ ParserResult Vp9VideoParser::ParsePictureData(const uint8_t *p_stream, uint32_t 
                     return ret;
                 }
                 if ((ret = SendPicForDecode()) != PARSER_OK) {
-                    ERR(STR("Failed to decode!"));
+                    logger_.ErrorLog(MakeMsg(STR("Failed to decode!")));
                     return ret;
                 }
         #if DBGINFO
@@ -213,7 +213,7 @@ ParserResult Vp9VideoParser::NotifyNewSequence(Vp9UncompressedHeader *p_uncomp_h
     } else if (p_uncomp_header->color_config.subsampling_x == 0 && p_uncomp_header->color_config.subsampling_y == 0) {
         video_format_params_.chroma_format = rocDecVideoChromaFormat_444;
     } else {
-        ERR("Unsupported chroma format.");
+        logger_.ErrorLog(MakeMsg("Unsupported chroma format."));
         return PARSER_INVALID_FORMAT;
     }
 
@@ -238,7 +238,7 @@ ParserResult Vp9VideoParser::NotifyNewSequence(Vp9UncompressedHeader *p_uncomp_h
 
     // callback function with RocdecVideoFormat params filled out
     if (pfn_sequence_cb_(parser_params_.user_data, &video_format_params_) == 0) {
-        ERR("Sequence callback function failed.");
+        logger_.ErrorLog(MakeMsg("Sequence callback function failed."));
         return PARSER_FAIL;
     } else {
         return PARSER_OK;
@@ -335,7 +335,7 @@ ParserResult Vp9VideoParser::SendPicForDecode() {
 #endif // DBGINFO
 
     if (pfn_decode_picture_cb_(parser_params_.user_data, &dec_pic_params_) == 0) {
-        ERR("Decode error occurred.");
+        logger_.ErrorLog(MakeMsg("Decode error occurred."));
         return PARSER_FAIL;
     } else {
         return PARSER_OK;
@@ -390,7 +390,7 @@ ParserResult Vp9VideoParser::FindFreeInDecBufPool() {
         }
     }
     if (dec_buf_index == dec_buf_pool_size_) {
-        ERR("Could not find a free buffer in decode buffer pool for decoded image.");
+        logger_.ErrorLog(MakeMsg("Could not find a free buffer in decode buffer pool for decoded image."));
         return PARSER_NOT_FOUND;
     }
     curr_pic_.dec_buf_idx = dec_buf_index;
@@ -407,7 +407,7 @@ ParserResult Vp9VideoParser::FindFreeInDpbAndMark() {
         }
     }
     if (i == VP9_BUFFER_POOL_MAX_SIZE) {
-        ERR("DPB buffer overflow!");
+        logger_.ErrorLog(MakeMsg("DPB buffer overflow!"));
         return PARSER_NOT_FOUND;
     }
     curr_pic_.pic_idx = i;
@@ -424,7 +424,7 @@ ParserResult Vp9VideoParser::FindFreeInDpbAndMark() {
             output_pic_list_[num_output_pics_] = disp_idx;
             num_output_pics_++;
         } else {
-            ERR("Display list size larger than decode buffer pool size!");
+            logger_.ErrorLog(MakeMsg("Display list size larger than decode buffer pool size!"));
             return PARSER_OUT_OF_RANGE;
         }
     }
@@ -453,7 +453,7 @@ ParserResult Vp9VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
     if (p_uncomp_header->profile == 3) {
         p_uncomp_header->reserved_zero = Parser::GetBit(p_stream, offset);
         if (p_uncomp_header->reserved_zero) {
-            ERR("Syntax error: reserved_zero in Uncompressed header is not 0 when Profile is 3");
+            logger_.ErrorLog(MakeMsg("Syntax error: reserved_zero in Uncompressed header is not 0 when Profile is 3"));
             return PARSER_INVALID_ARG;
         }
     }
@@ -529,7 +529,7 @@ ParserResult Vp9VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
         }
     }
     if (p_uncomp_header->frame_size.frame_width == 0 && p_uncomp_header->frame_size.frame_height == 0) {
-        ERR("Invalid picture size: width = " + TOSTR(p_uncomp_header->frame_size.frame_width) + ", height = " + TOSTR(p_uncomp_header->frame_size.frame_height) + ".");
+        logger_.ErrorLog(MakeMsg("Invalid picture size: width = " + TOSTR(p_uncomp_header->frame_size.frame_width) + ", height = " + TOSTR(p_uncomp_header->frame_size.frame_height) + "."));
         return PARSER_WRONG_STATE;
     }
 
@@ -578,7 +578,7 @@ ParserResult Vp9VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
             if (pic_width_ <= curr_surface_width_ && pic_height_ <= curr_surface_height_) {
                 reconfig_option_ = ROCDEC_RECONFIG_KEEP_SURFACES; // Keep the existing surfaces
             } else {
-                ERR("VP9 video size (up) change on non-key frames is not supported.");
+                logger_.ErrorLog(MakeMsg("VP9 video size (up) change on non-key frames is not supported."));
                 return PARSER_WRONG_STATE;
             }
         }
@@ -586,11 +586,11 @@ ParserResult Vp9VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
     }
     uncomp_header_size_ = (offset + 7) >> 3;
     if (uncomp_header_size_ > size) {
-        ERR("Uncompressed header size (" + TOSTR(uncomp_header_size_) + ") exceeds frame data size (" + TOSTR(size) + ")");
+        logger_.ErrorLog(MakeMsg("Uncompressed header size (" + TOSTR(uncomp_header_size_) + ") exceeds frame data size (" + TOSTR(size) + ")"));
         return PARSER_WRONG_STATE;
     }
     if (p_uncomp_header->header_size_in_bytes > (size - uncomp_header_size_)) {
-        ERR("header_size_in_bytes (" + TOSTR(p_uncomp_header->header_size_in_bytes) + ") exceeds allowed size (" + TOSTR(size - uncomp_header_size_) + ")");
+        logger_.ErrorLog(MakeMsg("header_size_in_bytes (" + TOSTR(p_uncomp_header->header_size_in_bytes) + ") exceeds allowed size (" + TOSTR(size - uncomp_header_size_) + ")"));
         return PARSER_WRONG_STATE;
     }
     return PARSER_OK;
@@ -599,17 +599,17 @@ ParserResult Vp9VideoParser::ParseUncompressedHeader(uint8_t *p_stream, size_t s
 ParserResult Vp9VideoParser::FrameSyncCode(const uint8_t *p_stream, size_t &offset, Vp9UncompressedHeader *p_uncomp_header) {
     p_uncomp_header->frame_sync_code.frame_sync_byte_0 = Parser::ReadBits(p_stream, offset, 8);
     if (p_uncomp_header->frame_sync_code.frame_sync_byte_0 != 0x49) {
-        ERR("Syntax error: frame_sync_byte_0 is " + TOSTR(p_uncomp_header->frame_sync_code.frame_sync_byte_0) + " but shall be equal to 0x49.");
+        logger_.ErrorLog(MakeMsg("Syntax error: frame_sync_byte_0 is " + TOSTR(p_uncomp_header->frame_sync_code.frame_sync_byte_0) + " but shall be equal to 0x49."));
         return PARSER_INVALID_ARG;
     }
     p_uncomp_header->frame_sync_code.frame_sync_byte_1 = Parser::ReadBits(p_stream, offset, 8);
     if (p_uncomp_header->frame_sync_code.frame_sync_byte_1 != 0x83) {
-        ERR("Syntax error: frame_sync_byte_1 is " + TOSTR(p_uncomp_header->frame_sync_code.frame_sync_byte_1) + " but shall be equal to 0x83.");
+        logger_.ErrorLog(MakeMsg("Syntax error: frame_sync_byte_1 is " + TOSTR(p_uncomp_header->frame_sync_code.frame_sync_byte_1) + " but shall be equal to 0x83."));
         return PARSER_INVALID_ARG;
     }
     p_uncomp_header->frame_sync_code.frame_sync_byte_2 = Parser::ReadBits(p_stream, offset, 8);
     if (p_uncomp_header->frame_sync_code.frame_sync_byte_2 != 0x42) {
-        ERR("Syntax error: frame_sync_byte_2 is " + TOSTR(p_uncomp_header->frame_sync_code.frame_sync_byte_2) + " but shall be equal to 0x42.");
+        logger_.ErrorLog(MakeMsg("Syntax error: frame_sync_byte_2 is " + TOSTR(p_uncomp_header->frame_sync_code.frame_sync_byte_2) + " but shall be equal to 0x42."));
         return PARSER_INVALID_ARG;
     }
     return PARSER_OK;
@@ -624,7 +624,7 @@ ParserResult Vp9VideoParser::ColorConfig(const uint8_t *p_stream, size_t &offset
     }
     p_uncomp_header->color_config.color_space = Parser::ReadBits(p_stream, offset, 3);
     if (p_uncomp_header->profile_low_bit == 0 && p_uncomp_header->color_config.color_space == CS_RGB) {
-        ERR("It is a requirement of bitstream conformance that color_space is not equal to CS_RGB when profile_low_bit is equal to 0.");
+        logger_.ErrorLog(MakeMsg("It is a requirement of bitstream conformance that color_space is not equal to CS_RGB when profile_low_bit is equal to 0."));
         return PARSER_WRONG_STATE;
     }
     if (p_uncomp_header->color_config.color_space != CS_RGB) {
@@ -634,7 +634,7 @@ ParserResult Vp9VideoParser::ColorConfig(const uint8_t *p_stream, size_t &offset
             p_uncomp_header->color_config.subsampling_y = Parser::GetBit(p_stream, offset);
             p_uncomp_header->color_config.reserved_zero = Parser::GetBit(p_stream, offset);
             if (p_uncomp_header->color_config.reserved_zero) {
-                ERR("Syntax error: reserved_zero in color config is not 0 when Profile is 1 or 3");
+                logger_.ErrorLog(MakeMsg("Syntax error: reserved_zero in color config is not 0 when Profile is 1 or 3"));
                 return PARSER_INVALID_ARG;
             }
         } else {
@@ -648,13 +648,13 @@ ParserResult Vp9VideoParser::ColorConfig(const uint8_t *p_stream, size_t &offset
             p_uncomp_header->color_config.subsampling_y = 0;
             p_uncomp_header->color_config.reserved_zero = Parser::GetBit(p_stream, offset);
             if (p_uncomp_header->color_config.reserved_zero) {
-                ERR("Syntax error: reserved_zero in color config is not 0 when Profile is 1 or 3");
+                logger_.ErrorLog(MakeMsg("Syntax error: reserved_zero in color config is not 0 when Profile is 1 or 3"));
                 return PARSER_INVALID_ARG;
             }
         }
     }
     if (p_uncomp_header->profile_low_bit == 1 && p_uncomp_header->color_config.subsampling_x == 1 && p_uncomp_header->color_config.subsampling_y == 1) {
-        ERR("It is a requirement of bitstream conformance that either subsampling_x is equal to 0 or subsampling_y is equal to 0 when profile_low_bit is equal to 1.");
+        logger_.ErrorLog(MakeMsg("It is a requirement of bitstream conformance that either subsampling_x is equal to 0 or subsampling_y is equal to 0 when profile_low_bit is equal to 1."));
         return PARSER_WRONG_STATE;
     }
     return PARSER_OK;
@@ -804,7 +804,7 @@ ParserResult Vp9VideoParser::SegmentationParams(const uint8_t *p_stream, size_t 
                             uint8_t feature_sign = Parser::GetBit(p_stream, offset);
                             if (feature_sign) {
                                 if (p_uncomp_header->segmentation_params.segmentation_abs_or_delta_update == 1) {
-                                    ERR("It is a requirement of bitstream conformance that feature_sign is equal to 0 when segmentation_abs_or_delta_update is equal to 1.");
+                                    logger_.ErrorLog(MakeMsg("It is a requirement of bitstream conformance that feature_sign is equal to 0 when segmentation_abs_or_delta_update is equal to 1."));
                                     return PARSER_WRONG_STATE;
                                 }
                                 feature_value *= -1;

--- a/src/rocdecode-host/avcodec/avcodec_videodecoder.cpp
+++ b/src/rocdecode-host/avcodec/avcodec_videodecoder.cpp
@@ -164,13 +164,13 @@ AvcodecVideoDecoder::~AvcodecVideoDecoder() {
 rocDecStatus AvcodecVideoDecoder::InitializeDecoder() {
     if (!decoder_) decoder_ = avcodec_find_decoder(RocDecVideoCodec2AVCodec(decoder_create_info_.codec_type));
     if(!decoder_) {
-        ERR("rocDecode<FFMpeg>:: Codec not supported by FFMpeg ");
+        logger_.CriticalLog(MakeMsg("rocDecode<FFMpeg>:: Codec not supported by FFMpeg "));
         return ROCDEC_NOT_SUPPORTED;
     }
     if (!dec_context_) {
         dec_context_ = avcodec_alloc_context3(decoder_);        //alloc dec_context_
         if (!dec_context_) {
-            ERR("Could not allocate video codec context");
+            logger_.CriticalLog(MakeMsg("Could not allocate video codec context"));
             return ROCDEC_RUNTIME_ERROR;
         }
         // set codec to automatically determine how many threads suits best for the decoding job
@@ -185,7 +185,7 @@ rocDecStatus AvcodecVideoDecoder::InitializeDecoder() {
 
         // open the codec
         if (avcodec_open2(dec_context_, decoder_, NULL) < 0) {
-            ERR("Could not open codec");
+            logger_.CriticalLog(MakeMsg("Could not open codec"));
             return ROCDEC_RUNTIME_ERROR;
         }
         // get the output pixel format from dec_context_
@@ -238,7 +238,7 @@ rocDecStatus AvcodecVideoDecoder::SubmitDecode(RocdecPicParamsHost *pPicParams) 
     if (pPicParams->bitstream_data_len > packet_data->second) {
         void *new_pkt_data = av_realloc(av_pkt->data, (pPicParams->bitstream_data_len + MAX_AV_PACKET_DATA_SIZE));  // add more to avoid frequence reallocation
         if (!new_pkt_data) {
-            ERR("ERROR: couldn't allocate packet data");
+            logger_.ErrorLog(MakeMsg("ERROR: couldn't allocate packet data"));
             return ROCDEC_OUTOF_MEMORY;
         }
         packet_data->first   = static_cast<uint8_t *>(new_pkt_data);
@@ -293,11 +293,11 @@ rocDecStatus AvcodecVideoDecoder::GetDecodeStatus(int pic_idx, RocdecDecodeStatu
 rocDecStatus AvcodecVideoDecoder::GetVideoFrame(int pic_idx, void **frame_ptr, uint32_t *line_size, RocdecProcParams *vid_postproc_params){
 
     if (p_disp_frame_ == nullptr) {
-        ERR("GetVideoFrame: No frame available to display");
+        logger_.ErrorLog(MakeMsg("GetVideoFrame: No frame available to display"));
         return ROCDEC_RUNTIME_ERROR;
     }
     if (p_disp_frame_->picture_index != pic_idx) {
-        ERR("GetVideoFrame: pic_index is invalid" );
+        logger_.ErrorLog(MakeMsg("GetVideoFrame: pic_index is invalid"));
         return ROCDEC_INVALID_PARAMETER;
     }
     auto p_av_frame = p_disp_frame_->av_frame_ptr;
@@ -342,7 +342,7 @@ int AvcodecVideoDecoder::DecodeAvFrame(AVPacket *av_pkt, AVFrame *p_frame) {
     status = avcodec_send_packet(dec_context_, av_pkt);
     if (status < 0) {
         if (av_pkt->data && av_pkt->size)
-            ERR("Error sending av packet for decoding: status: ");
+            logger_.ErrorLog(MakeMsg("Error sending av packet for decoding: status:"));
         return status;
     }
     while (status >= 0) {
@@ -353,7 +353,7 @@ int AvcodecVideoDecoder::DecodeAvFrame(AVPacket *av_pkt, AVFrame *p_frame) {
             return 0;
         }
         else if (status < 0) {
-            ERR("Error during decoding");
+            logger_.ErrorLog(MakeMsg("Error during decoding"));
             return 0;
         }
         // for the first frame, initialize OutputsurfaceInfo
@@ -403,7 +403,7 @@ rocDecStatus AvcodecVideoDecoder::NotifyNewSequence(AVFrame *p_frame) {
     p_video_format->display_aspect_ratio.y = p_frame->sample_aspect_ratio.den;
     if (pfn_sequece_cb_ && decoder_create_info_.user_data && 
         pfn_sequece_cb_(decoder_create_info_.user_data, &video_format_host_) == 0) {
-        ERR("Sequence callback function failed.");
+        logger_.CriticalLog(MakeMsg("Sequence callback function failed."));
         return ROCDEC_RUNTIME_ERROR;
     } else {
         return ROCDEC_SUCCESS;

--- a/src/rocdecode-host/avcodec/avcodec_videodecoder.h
+++ b/src/rocdecode-host/avcodec/avcodec_videodecoder.h
@@ -164,4 +164,5 @@ private:
     AVFormatContext * formatContext = nullptr;
     AVInputFormat * inputFormat = nullptr;
 
+    RocDecLogger logger_;
 };

--- a/src/rocdecode-host/roc_decoder_host.cpp
+++ b/src/rocdecode-host/roc_decoder_host.cpp
@@ -30,12 +30,12 @@ RocDecoderHost::~RocDecoderHost() {}
 rocDecStatus RocDecoderHost::InitializeDecoder() {
     rocDecStatus rocdec_status = ROCDEC_SUCCESS;
     if (!decoder_create_info_.user_data) {
-        ERR("Invalid function callback pointer passed");
+        logger_.CriticalLog(MakeMsg("Invalid function callback pointer passed"));
         return ROCDEC_NOT_INITIALIZED;
     }
     rocdec_status = avcodec_video_decoder_.InitializeDecoder();
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to initialize the FFMpeg Video decoder.");
+        logger_.CriticalLog(MakeMsg("Failed to initialize the FFMpeg Video decoder."));
         return rocdec_status;
     }
      return rocdec_status;
@@ -45,7 +45,7 @@ rocDecStatus RocDecoderHost::DecodeFrame(RocdecPicParamsHost *pic_params) {
     rocDecStatus rocdec_status = ROCDEC_SUCCESS;
     rocdec_status = avcodec_video_decoder_.SubmitDecode(pic_params);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Decode submission is not successful.");
+        logger_.ErrorLog(MakeMsg("Decode submission is not successful."));
     }
 
      return rocdec_status;
@@ -55,7 +55,7 @@ rocDecStatus RocDecoderHost::GetDecodeStatus(int pic_idx, RocdecDecodeStatus* de
     rocDecStatus rocdec_status = ROCDEC_SUCCESS;
     rocdec_status = avcodec_video_decoder_.GetDecodeStatus(pic_idx, decode_status);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to query the decode status.");
+        logger_.ErrorLog(MakeMsg("Failed to query the decode status."));
     }
     return rocdec_status;
 }
@@ -66,7 +66,7 @@ rocDecStatus RocDecoderHost::ReconfigureDecoder(RocdecReconfigureDecoderInfo *re
     }
     rocDecStatus rocdec_status = avcodec_video_decoder_.ReconfigureDecoder(reconfig_params);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Reconfiguration of the decoder failed.");
+        logger_.CriticalLog(MakeMsg("Reconfiguration of the decoder failed."));
         return rocdec_status;
     }
     return rocdec_status;
@@ -78,7 +78,7 @@ rocDecStatus RocDecoderHost::GetVideoFrame(int pic_idx, void **frame_ptr, uint32
     }
     rocDecStatus rocdec_status = avcodec_video_decoder_.GetVideoFrame(pic_idx, frame_ptr, line_size, vid_postproc_params);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("GetVideoFrame failed.");
+        logger_.ErrorLog(MakeMsg("GetVideoFrame failed."));
         return rocdec_status;
     }
     return rocdec_status;

--- a/src/rocdecode-host/roc_decoder_host.h
+++ b/src/rocdecode-host/roc_decoder_host.h
@@ -48,4 +48,6 @@ public:
 private:
     AvcodecVideoDecoder avcodec_video_decoder_;
     RocDecoderHostCreateInfo decoder_create_info_;
+
+    RocDecLogger logger_;
 };

--- a/src/rocdecode-host/rocdecode_host_api.cpp
+++ b/src/rocdecode-host/rocdecode_host_api.cpp
@@ -37,7 +37,7 @@ rocDecCreateDecoderHost(rocDecDecoderHandle *decoder_handle, RocDecoderHostCreat
         handle = new DecHandleHost(*decoder_create_info);
     }
     catch(const std::exception& e) {
-        ERR( STR("Failed to init the rocDecode handle, ") + STR(e.what()))
+        RocDecLogger::AlwaysLog(STR("Error: Failed to init the rocDecode handle, ") + STR(e.what()));
         return ROCDEC_NOT_INITIALIZED;
     }
     *decoder_handle = handle;
@@ -92,7 +92,7 @@ rocDecDecodeFrameHost(rocDecDecoderHandle decoder_handle, _RocdecPicParamsHost *
     }
     catch(const std::exception& e) {
         handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;
@@ -116,7 +116,7 @@ rocDecGetDecodeStatusHost(rocDecDecoderHandle decoder_handle, int pic_idx, Rocde
     }
     catch(const std::exception& e) {
         handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;
@@ -139,7 +139,7 @@ rocDecReconfigureDecoderHost(rocDecDecoderHandle decoder_handle, RocdecReconfigu
     }
     catch(const std::exception& e) {
         handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;
@@ -165,7 +165,7 @@ rocDecGetVideoFrameHost(rocDecDecoderHandle decoder_handle, int pic_idx,
     }
     catch(const std::exception& e) {
         handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;

--- a/src/rocdecode/roc_decoder.cpp
+++ b/src/rocdecode/roc_decoder.cpp
@@ -31,13 +31,13 @@ RocDecoder::RocDecoder(RocDecoderCreateInfo& decoder_create_info): va_video_deco
         if (hip_interop_[i].hip_mapped_device_mem != nullptr) {
             hipError_t hip_status = hipFree(hip_interop_[i].hip_mapped_device_mem);
             if (hip_status != hipSuccess) {
-                ERR("hipFree failed for picture idx = " + TOSTR(i));
+                logger_.CriticalLog(MakeMsg("hipFree failed for picture idx = " + TOSTR(i)));
             }
         }
         if (hip_interop_[i].hip_ext_mem != nullptr) {
             hipError_t hip_status = hipDestroyExternalMemory(hip_interop_[i].hip_ext_mem);
             if (hip_status != hipSuccess) {
-                ERR("hipDestroyExternalMemory failed for picture idx = " + TOSTR(i));
+                logger_.CriticalLog(MakeMsg("hipDestroyExternalMemory failed for picture idx = " + TOSTR(i)));
             }
         }
     }
@@ -46,7 +46,7 @@ RocDecoder::RocDecoder(RocDecoderCreateInfo& decoder_create_info): va_video_deco
  rocDecStatus RocDecoder::InitializeDecoder() {
     rocDecStatus rocdec_status = ROCDEC_SUCCESS;
     if (decoder_create_info_.num_decode_surfaces < 1) {
-        ERR("Invalid number of decode surfaces.");
+        logger_.CriticalLog(MakeMsg("Invalid number of decode surfaces."));
         return ROCDEC_INVALID_PARAMETER;
     }
     hip_interop_.resize(decoder_create_info_.num_decode_surfaces);
@@ -55,7 +55,7 @@ RocDecoder::RocDecoder(RocDecoderCreateInfo& decoder_create_info): va_video_deco
     }
     rocdec_status = va_video_decoder_.InitializeDecoder();
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to initilize the VAAPI Video decoder.");
+        logger_.CriticalLog(MakeMsg("Failed to initilize the VAAPI Video decoder."));
         return rocdec_status;
     }
 
@@ -66,7 +66,7 @@ rocDecStatus RocDecoder::DecodeFrame(RocdecPicParams *pic_params) {
     rocDecStatus rocdec_status = ROCDEC_SUCCESS;
     rocdec_status = va_video_decoder_.SubmitDecode(pic_params);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Decode submission is not successful.");
+        logger_.ErrorLog(MakeMsg("Decode submission is not successful."));
     }
 
      return rocdec_status;
@@ -76,7 +76,7 @@ rocDecStatus RocDecoder::GetDecodeStatus(int pic_idx, RocdecDecodeStatus* decode
     rocDecStatus rocdec_status = ROCDEC_SUCCESS;
     rocdec_status = va_video_decoder_.GetDecodeStatus(pic_idx, decode_status);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to query the decode status.");
+        logger_.ErrorLog(MakeMsg("Failed to query the decode status."));
     }
     return rocdec_status;
 }
@@ -90,7 +90,7 @@ rocDecStatus RocDecoder::ReconfigureDecoder(RocdecReconfigureDecoderInfo *reconf
     for (int pic_idx = 0; pic_idx < hip_interop_.size(); pic_idx++) {
         rocdec_status = FreeVideoFrame(pic_idx);
         if (rocdec_status != ROCDEC_SUCCESS) {
-            ERR("Releasing the video frame for picture idx = " + TOSTR(pic_idx) + " failed during reconfiguration.");
+            logger_.ErrorLog(MakeMsg("Releasing the video frame for picture idx = " + TOSTR(pic_idx) + " failed during reconfiguration."));
             return rocdec_status;
         }
     }
@@ -99,7 +99,7 @@ rocDecStatus RocDecoder::ReconfigureDecoder(RocdecReconfigureDecoderInfo *reconf
     }
     rocdec_status = va_video_decoder_.ReconfigureDecoder(reconfig_params);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Reconfiguration of the decoder failed.");
+        logger_.CriticalLog(MakeMsg("Reconfiguration of the decoder failed."));
         return rocdec_status;
     }
     return rocdec_status;
@@ -114,7 +114,7 @@ rocDecStatus RocDecoder::GetVideoFrame(int pic_idx, void *dev_mem_ptr[3], uint32
     // wait on current surface to make sure that it is ready for the HIP interop
     rocdec_status = va_video_decoder_.SyncSurface(pic_idx);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to export surface for picture idx = " + TOSTR(pic_idx));
+        logger_.ErrorLog(MakeMsg("Failed to export surface for picture idx = " + TOSTR(pic_idx)));
         return rocdec_status;
     }
 
@@ -126,7 +126,7 @@ rocDecStatus RocDecoder::GetVideoFrame(int pic_idx, void *dev_mem_ptr[3], uint32
 
         rocdec_status = va_video_decoder_.ExportSurface(pic_idx, va_drm_prime_surface_desc);
         if (rocdec_status != ROCDEC_SUCCESS) {
-            ERR("Failed to export surface for picture idx = " + TOSTR(pic_idx));
+            logger_.ErrorLog(MakeMsg("Failed to export surface for picture idx = " + TOSTR(pic_idx)));
             return rocdec_status;
         }
 

--- a/src/rocdecode/roc_decoder.h
+++ b/src/rocdecode/roc_decoder.h
@@ -59,4 +59,6 @@ private:
     VaapiVideoDecoder va_video_decoder_;
     RocDecoderCreateInfo decoder_create_info_;
     std::vector<HipInteropDeviceMem> hip_interop_;
+
+    RocDecLogger logger_;
 };

--- a/src/rocdecode/rocdecode_api.cpp
+++ b/src/rocdecode/rocdecode_api.cpp
@@ -39,7 +39,7 @@ rocDecCreateDecoder(rocDecDecoderHandle *decoder_handle, RocDecoderCreateInfo *d
         handle = new DecHandle(*decoder_create_info);
     }
     catch(const std::exception& e) {
-        ERR( STR("Failed to init the rocDecode handle, ") + STR(e.what()))
+        RocDecLogger::AlwaysLog(STR("Error: Failed to init the rocDecode handle, ") + STR(e.what()));
         return ROCDEC_NOT_INITIALIZED;
     }
     *decoder_handle = handle;
@@ -75,7 +75,7 @@ rocDecGetDecoderCaps(RocdecDecodeCaps *pdc) {
     VaContext& va_ctx = VaContext::GetInstance();
     rocDecStatus ret = ROCDEC_SUCCESS;
     if ((ret = va_ctx.CheckDecCapForCodecType(pdc)) != ROCDEC_SUCCESS) {
-        ERR("Failed to obtain decoder capabilities from driver.");
+        RocDecLogger::AlwaysLog("Error: Failed to obtain decoder capabilities from driver.");
         return ret;
     } else {
         return ROCDEC_SUCCESS;
@@ -99,7 +99,7 @@ rocDecDecodeFrame(rocDecDecoderHandle decoder_handle, RocdecPicParams *pic_param
     }
     catch(const std::exception& e) {
         handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;
@@ -124,7 +124,7 @@ rocDecGetDecodeStatus(rocDecDecoderHandle decoder_handle, int pic_idx, RocdecDec
     }
     catch(const std::exception& e) {
         handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;
@@ -147,7 +147,7 @@ rocDecReconfigureDecoder(rocDecDecoderHandle decoder_handle, RocdecReconfigureDe
     }
     catch(const std::exception& e) {
         handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;
@@ -174,7 +174,7 @@ rocDecGetVideoFrame(rocDecDecoderHandle decoder_handle, int pic_idx,
     }
     catch(const std::exception& e) {
         handle->CaptureError(e.what());
-        ERR(e.what())
+        RocDecLogger::AlwaysLog(e.what());
         return ROCDEC_RUNTIME_ERROR;
     }
     return ret;

--- a/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -32,27 +32,27 @@ VaapiVideoDecoder::~VaapiVideoDecoder() {
         rocDecStatus rocdec_status = ROCDEC_SUCCESS;
         rocdec_status = DestroyDataBuffers();
         if (rocdec_status != ROCDEC_SUCCESS) {
-            ERR("DestroyDataBuffers failed");
+            logger_.CriticalLog(MakeMsg("DestroyDataBuffers failed"));
         }
         VAStatus va_status = VA_STATUS_SUCCESS;
         va_status = vaDestroySurfaces(va_display_, va_surface_ids_.data(), va_surface_ids_.size());
         if (va_status != VA_STATUS_SUCCESS) {
-            ERR("vaDestroySurfaces failed");
+            logger_.CriticalLog(MakeMsg("vaDestroySurfaces failed"));
         }
         if (va_context_id_) {
             va_status = vaDestroyContext(va_display_, va_context_id_);
             if (va_status != VA_STATUS_SUCCESS) {
-                ERR("vaDestroyContext failed");
+                logger_.CriticalLog(MakeMsg("vaDestroyContext failed"));
             }
         }
         if (va_config_id_) {
             va_status = vaDestroyConfig(va_display_, va_config_id_);
             if (va_status != VA_STATUS_SUCCESS) {
-                ERR("vaDestroyConfig failed");
+                logger_.CriticalLog(MakeMsg("vaDestroyConfig failed"));
             }
         }
         if (vaTerminate(va_display_) != VA_STATUS_SUCCESS) {
-            ERR("Failed to termiate VA");
+            logger_.CriticalLog(MakeMsg("Failed to termiate VA"));
         }
     }
 }
@@ -63,33 +63,33 @@ rocDecStatus VaapiVideoDecoder::InitializeDecoder() {
     // Before initializing the VAAPI, first check to see if the requested codec config is supported
     if (!IsCodecConfigSupported(decoder_create_info_.device_id, decoder_create_info_.codec_type, decoder_create_info_.chroma_format,
         decoder_create_info_.bit_depth_minus_8, decoder_create_info_.output_format)) {
-        ERR("The codec config combination is not supported.");
+        logger_.CriticalLog(MakeMsg("The codec config combination is not supported."));
         return ROCDEC_NOT_SUPPORTED;
     }
 
     VaContext& va_ctx = VaContext::GetInstance();
     uint32_t va_ctx_id;
     if ((rocdec_status = va_ctx.GetVaContext(decoder_create_info_.device_id, &va_ctx_id)) != ROCDEC_SUCCESS) {
-        ERR("Failed to get VA context.");
+        logger_.CriticalLog(MakeMsg("Failed to get VA context."));
         return rocdec_status;
     }
     if ((rocdec_status = va_ctx.GetVaDisplay(va_ctx_id, &va_display_)) != ROCDEC_SUCCESS) {
-        ERR("Failed to get VA display.");
+        logger_.CriticalLog(MakeMsg("Failed to get VA display."));
         return rocdec_status;
     }
     rocdec_status = CreateDecoderConfig();
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to create a VAAPI decoder configuration.");
+        logger_.CriticalLog(MakeMsg("Failed to create a VAAPI decoder configuration."));
         return rocdec_status;
     }
     rocdec_status = CreateSurfaces();
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to create VAAPI surfaces.");
+        logger_.CriticalLog(MakeMsg("Failed to create VAAPI surfaces."));
         return rocdec_status;
     }
     rocdec_status = CreateContext();
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to create a VAAPI context.");
+        logger_.CriticalLog(MakeMsg("Failed to create a VAAPI context."));
         return rocdec_status;
     }
     return rocdec_status;
@@ -103,7 +103,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
 
     // Get the surface id for the current picture, assuming 1:1 mapping between DPB and VAAPI decoded surfaces.
     if (pPicParams->curr_pic_idx >= va_surface_ids_.size() || pPicParams->curr_pic_idx < 0) {
-        ERR("curr_pic_idx exceeded the VAAPI surface pool limit.");
+        logger_.ErrorLog(MakeMsg("curr_pic_idx exceeded the VAAPI surface pool limit."));
         return ROCDEC_INVALID_PARAMETER;
     }
     curr_surface_id = va_surface_ids_[pPicParams->curr_pic_idx];
@@ -115,7 +115,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
             for (int i = 0; i < 15; i++) {
                 if (pPicParams->pic_params.hevc.ref_frames[i].pic_idx != 0xFF) {
                     if (pPicParams->pic_params.hevc.ref_frames[i].pic_idx >= va_surface_ids_.size() || pPicParams->pic_params.hevc.ref_frames[i].pic_idx < 0) {
-                        ERR("Reference frame index exceeded the VAAPI surface pool limit.");
+                        logger_.ErrorLog(MakeMsg("Reference frame index exceeded the VAAPI surface pool limit."));
                         return ROCDEC_INVALID_PARAMETER;
                     }
                     pPicParams->pic_params.hevc.ref_frames[i].pic_idx = va_surface_ids_[pPicParams->pic_params.hevc.ref_frames[i].pic_idx];
@@ -135,7 +135,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
 
             if ((pic_params_size != sizeof(VAPictureParameterBufferHEVC)) || (scaling_list_enabled && (iq_matrix_size != sizeof(VAIQMatrixBufferHEVC))) || 
                 (slice_params_size != sizeof(VASliceParameterBufferHEVC))) {
-                    ERR("HEVC data_buffer parameter_size not matching vaapi parameter buffer size.");
+                    logger_.ErrorLog(MakeMsg("HEVC data_buffer parameter_size not matching vaapi parameter buffer size."));
                     return ROCDEC_RUNTIME_ERROR;
             }
             break;
@@ -146,7 +146,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
             for (int i = 0; i < 16; i++) {
                 if (pPicParams->pic_params.avc.ref_frames[i].pic_idx != 0xFF) {
                     if (pPicParams->pic_params.avc.ref_frames[i].pic_idx >= va_surface_ids_.size() || pPicParams->pic_params.avc.ref_frames[i].pic_idx < 0) {
-                        ERR("Reference frame index exceeded the VAAPI surface pool limit.");
+                        logger_.ErrorLog(MakeMsg("Reference frame index exceeded the VAAPI surface pool limit."));
                         return ROCDEC_INVALID_PARAMETER;
                     }
                     pPicParams->pic_params.avc.ref_frames[i].pic_idx = va_surface_ids_[pPicParams->pic_params.avc.ref_frames[i].pic_idx];
@@ -163,7 +163,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
             slice_params_size = sizeof(RocdecAvcSliceParams);
 
             if ((pic_params_size != sizeof(VAPictureParameterBufferH264)) || (iq_matrix_size != sizeof(VAIQMatrixBufferH264)) || (slice_params_size != sizeof(VASliceParameterBufferH264))) {
-                    ERR("AVC data_buffer parameter_size not matching vaapi parameter buffer size.");
+                    logger_.ErrorLog(MakeMsg("AVC data_buffer parameter_size not matching vaapi parameter buffer size."));
                     return ROCDEC_RUNTIME_ERROR;
             }
             break;
@@ -173,7 +173,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
             for (int i = 0; i < 8; i++) {
                 if (pPicParams->pic_params.vp9.reference_frames[i] != 0xFF) {
                     if (pPicParams->pic_params.vp9.reference_frames[i] >= va_surface_ids_.size()) {
-                        ERR("Reference frame index exceeded the VAAPI surface pool limit.");
+                        logger_.ErrorLog(MakeMsg("Reference frame index exceeded the VAAPI surface pool limit."));
                         return ROCDEC_INVALID_PARAMETER;
                     }
                     pPicParams->pic_params.vp9.reference_frames[i] = va_surface_ids_[pPicParams->pic_params.vp9.reference_frames[i]];
@@ -184,7 +184,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
             slice_params_ptr = (void*)pPicParams->slice_params.vp9;
             slice_params_size = sizeof(RocdecVp9SliceParams);
             if ((pic_params_size != sizeof(VADecPictureParameterBufferVP9)) || (slice_params_size != sizeof(VASliceParameterBufferVP9))) {
-                    ERR("VP9 data_buffer parameter_size not matching vaapi parameter buffer size.");
+                    logger_.ErrorLog(MakeMsg("VP9 data_buffer parameter_size not matching vaapi parameter buffer size."));
                     return ROCDEC_RUNTIME_ERROR;
             }
             break;
@@ -195,7 +195,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
 
             if (pPicParams->pic_params.av1.current_display_picture != 0xFF) {
                 if (pPicParams->pic_params.av1.current_display_picture >= va_surface_ids_.size() || pPicParams->pic_params.av1.current_display_picture < 0) {
-                    ERR("Current display picture index exceeded the VAAPI surface pool limit.");
+                    logger_.ErrorLog(MakeMsg("Current display picture index exceeded the VAAPI surface pool limit."));
                     return ROCDEC_INVALID_PARAMETER;
                 }
                 pPicParams->pic_params.av1.current_display_picture = va_surface_ids_[pPicParams->pic_params.av1.current_display_picture];
@@ -203,7 +203,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
 
             for (int i = 0; i < pPicParams->pic_params.av1.anchor_frames_num; i++) {
                 if (pPicParams->pic_params.av1.anchor_frames_list[i] >= va_surface_ids_.size() || pPicParams->pic_params.av1.anchor_frames_list[i] < 0) {
-                    ERR("Anchor frame index exceeded the VAAPI surface pool limit.");
+                    logger_.ErrorLog(MakeMsg("Anchor frame index exceeded the VAAPI surface pool limit."));
                     return ROCDEC_INVALID_PARAMETER;
                 }
                 pPicParams->pic_params.av1.anchor_frames_list[i] = va_surface_ids_[pPicParams->pic_params.av1.anchor_frames_list[i]];
@@ -212,7 +212,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
             for (int i = 0; i < 8; i++) {
                 if (pPicParams->pic_params.av1.ref_frame_map[i] != 0xFF) {
                     if (pPicParams->pic_params.av1.ref_frame_map[i] >= va_surface_ids_.size() || pPicParams->pic_params.av1.ref_frame_map[i] < 0) {
-                        ERR("Reference frame index exceeded the VAAPI surface pool limit.");
+                        logger_.ErrorLog(MakeMsg("Reference frame index exceeded the VAAPI surface pool limit."));
                         return ROCDEC_INVALID_PARAMETER;
                     }
                     pPicParams->pic_params.av1.ref_frame_map[i] = va_surface_ids_[pPicParams->pic_params.av1.ref_frame_map[i]];
@@ -226,14 +226,14 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
             slice_params_size = sizeof(RocdecAv1SliceParams);
 
             if ((pic_params_size != sizeof(VADecPictureParameterBufferAV1)) || (slice_params_size != sizeof(VASliceParameterBufferAV1))) {
-                    ERR("AV1 data_buffer parameter_size not matching vaapi parameter buffer size.");
+                    logger_.CriticalLog(MakeMsg("AV1 data_buffer parameter_size not matching vaapi parameter buffer size."));
                     return ROCDEC_RUNTIME_ERROR;
             }
             break;
         }
 
         default: {
-            ERR("The codec type is not supported.");
+            logger_.CriticalLog(MakeMsg("The codec type is not supported."));
             return ROCDEC_NOT_SUPPORTED;
         }
     }
@@ -241,7 +241,7 @@ rocDecStatus VaapiVideoDecoder::SubmitDecode(RocdecPicParams *pPicParams) {
     // Destroy the data buffers of the previous frame
     rocDecStatus rocdec_status = DestroyDataBuffers();
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to destroy VAAPI buffer.");
+        logger_.CriticalLog(MakeMsg("Failed to destroy VAAPI buffer."));
         return rocdec_status;
     }
 
@@ -318,7 +318,7 @@ rocDecStatus VaapiVideoDecoder::ReconfigureDecoder(RocdecReconfigureDecoderInfo 
         return ROCDEC_INVALID_PARAMETER;
     }
     if (va_display_ == 0) {
-        ERR("VAAPI decoder has not been initialized but reconfiguration of the decoder has been requested.");
+        logger_.CriticalLog(MakeMsg("VAAPI decoder has not been initialized but reconfiguration of the decoder has been requested."));
         return ROCDEC_NOT_SUPPORTED;
     }
     CHECK_VAAPI(vaDestroySurfaces(va_display_, va_surface_ids_.data(), va_surface_ids_.size()));
@@ -345,18 +345,18 @@ rocDecStatus VaapiVideoDecoder::ReconfigureDecoder(RocdecReconfigureDecoderInfo 
     if (create_va_config) {
         rocdec_status = CreateDecoderConfig();
         if (rocdec_status != ROCDEC_SUCCESS) {
-            ERR("Failed to create a VAAPI decoder configuration.");
+            logger_.CriticalLog(MakeMsg("Failed to create a VAAPI decoder configuration."));
             return rocdec_status;
         }
     }
     rocdec_status = CreateSurfaces();
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to create VAAPI surfaces during the decoder reconfiguration.");
+        logger_.CriticalLog(MakeMsg("Failed to create VAAPI surfaces during the decoder reconfiguration."));
         return rocdec_status;
     }
     rocdec_status = CreateContext();
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to create a VAAPI context during the decoder reconfiguration.");
+        logger_.CriticalLog(MakeMsg("Failed to create a VAAPI context during the decoder reconfiguration."));
         return rocdec_status;
     }
     return rocdec_status;
@@ -405,7 +405,7 @@ rocDecStatus VaapiVideoDecoder::CreateDecoderConfig() {
             }
             break;
         default:
-            ERR("The codec type is not supported.");
+            logger_.CriticalLog(MakeMsg("The codec type is not supported."));
             return ROCDEC_NOT_SUPPORTED;
     }
     va_config_attrib_.type = VAConfigAttribRTFormat;
@@ -426,7 +426,7 @@ rocDecStatus VaapiVideoDecoder::CreateDecoderConfig() {
 
 rocDecStatus VaapiVideoDecoder::CreateSurfaces() {
     if (decoder_create_info_.num_decode_surfaces < 1) {
-        ERR("Invalid number of decode surfaces.");
+        logger_.CriticalLog(MakeMsg("Invalid number of decode surfaces."));
         return ROCDEC_INVALID_PARAMETER;
     }
     va_surface_ids_.resize(decoder_create_info_.num_decode_surfaces);
@@ -460,7 +460,7 @@ rocDecStatus VaapiVideoDecoder::CreateSurfaces() {
             surface_format = VA_RT_FORMAT_YUV444;
             break;
         default:
-            ERR("The surface type is not supported");
+            logger_.CriticalLog(MakeMsg("The surface type is not supported"));
             return ROCDEC_NOT_SUPPORTED;
     }
     surf_attribs.push_back(surf_attrib);
@@ -519,7 +519,7 @@ VaContext::~VaContext() {
         }
         if (va_contexts_[i].va_display) {
             if (vaTerminate(va_contexts_[i].va_display) != VA_STATUS_SUCCESS) {
-                ERR("Failed to termiate VA");
+                logger_.CriticalLog(MakeMsg("Failed to termiate VA"));
             }
         }
     }
@@ -533,7 +533,7 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
     rocDecStatus rocdec_status = ROCDEC_SUCCESS;
     rocdec_status = InitHIP(device_id, hip_dev_prop);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to initilize the HIP.");
+        logger_.CriticalLog(MakeMsg("Failed to initilize the HIP."));
         return rocdec_status;
     }
     std::string gpu_uuid(hip_dev_prop.uuid.bytes, sizeof(hip_dev_prop.uuid.bytes));
@@ -574,18 +574,18 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
         drm_node += std::to_string(render_node_id + offset);
         rocdec_status = InitVAAPI(va_ctx_idx, drm_node);
         if (rocdec_status != ROCDEC_SUCCESS) {
-            ERR("Failed to initilize the VAAPI.");
+            logger_.CriticalLog(MakeMsg("Failed to initilize the VAAPI."));
             return rocdec_status;
         }
 
         amdgpu_device_handle dev_handle;
         uint32_t major_version = 0, minor_version = 0;
         if (amdgpu_device_initialize(va_contexts_[va_ctx_idx].drm_fd, &major_version, &minor_version, &dev_handle)) {
-            ERR("GPU device initialization failed: " + drm_node);
+            logger_.CriticalLog(MakeMsg("GPU device initialization failed: " + drm_node));
             return ROCDEC_DEVICE_INVALID;
         }
         if (amdgpu_query_hw_ip_count(dev_handle, AMDGPU_HW_IP_VCN_DEC, &va_contexts_[va_ctx_idx].num_dec_engines)) {
-            ERR("Failed to get the number of video decode engines.");
+            logger_.CriticalLog(MakeMsg("Failed to get the number of video decode engines."));
         }
         amdgpu_device_deinitialize(dev_handle);
 
@@ -601,13 +601,13 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
 
 rocDecStatus VaContext::GetVaDisplay(uint32_t va_ctx_id, VADisplay *va_display) {
     if (va_ctx_id >= va_contexts_.size()) {
-        ERR("Invalid VA context Id.");
+        logger_.CriticalLog(MakeMsg("Invalid VA context Id."));
         *va_display = 0;
         return ROCDEC_INVALID_PARAMETER;
     } else {
         VADisplay new_va_display = vaGetDisplayDRM(va_contexts_[va_ctx_id].drm_fd);
         if (!new_va_display) {
-            ERR("Failed to create VA display.");
+            logger_.CriticalLog(MakeMsg("Failed to create VA display."));
             return ROCDEC_NOT_INITIALIZED;
         }
         vaSetInfoCallback(new_va_display, NULL, NULL);
@@ -620,14 +620,14 @@ rocDecStatus VaContext::GetVaDisplay(uint32_t va_ctx_id, VADisplay *va_display) 
 
 rocDecStatus VaContext::CheckDecCapForCodecType(RocdecDecodeCaps *dec_cap) {
     if (dec_cap == nullptr) {
-        ERR("Null decode capability struct pointer.");
+        logger_.CriticalLog(MakeMsg("Null decode capability struct pointer."));
         return ROCDEC_INVALID_PARAMETER;
     }
     rocDecStatus rocdec_status = ROCDEC_SUCCESS;
     uint32_t va_ctx_id;
     rocdec_status = GetVaContext(dec_cap->device_id, &va_ctx_id);
     if (rocdec_status != ROCDEC_SUCCESS) {
-        ERR("Failed to initilize.");
+        logger_.CriticalLog(MakeMsg("Failed to initilize."));
         return rocdec_status;
     }
 
@@ -810,11 +810,11 @@ rocDecStatus VaContext::CheckDecCapForCodecType(RocdecDecodeCaps *dec_cap) {
 rocDecStatus VaContext::InitHIP(int device_id, hipDeviceProp_t& hip_dev_prop) {
     CHECK_HIP(hipGetDeviceCount(&num_devices_));
     if (num_devices_ < 1) {
-        ERR("Didn't find any GPU.");
+        logger_.CriticalLog(MakeMsg("Didn't find any GPU."));
         return ROCDEC_DEVICE_INVALID;
     }
     if (device_id >= num_devices_) {
-        ERR("ERROR: the requested device_id is not found! ");
+        logger_.CriticalLog(MakeMsg("ERROR: the requested device_id is not found!"));
         return ROCDEC_DEVICE_INVALID;
     }   
     CHECK_HIP(hipSetDevice(device_id));
@@ -825,12 +825,12 @@ rocDecStatus VaContext::InitHIP(int device_id, hipDeviceProp_t& hip_dev_prop) {
 rocDecStatus VaContext::InitVAAPI(int va_ctx_idx, std::string drm_node) {
     va_contexts_[va_ctx_idx].drm_fd = open(drm_node.c_str(), O_RDWR);
     if (va_contexts_[va_ctx_idx].drm_fd < 0) {
-        ERR("Failed to open drm node." + drm_node);
+        logger_.CriticalLog(MakeMsg("Failed to open drm node." + drm_node));
         return ROCDEC_NOT_INITIALIZED;
     }
     va_contexts_[va_ctx_idx].va_display = vaGetDisplayDRM(va_contexts_[va_ctx_idx].drm_fd);
     if (!va_contexts_[va_ctx_idx].va_display) {
-        ERR("Failed to create VA display.");
+        logger_.CriticalLog(MakeMsg("Failed to create VA display."));
         return ROCDEC_NOT_INITIALIZED;
     }
     vaSetInfoCallback(va_contexts_[va_ctx_idx].va_display, NULL, NULL);

--- a/src/rocdecode/vaapi/vaapi_videodecoder.h
+++ b/src/rocdecode/vaapi/vaapi_videodecoder.h
@@ -45,7 +45,7 @@ THE SOFTWARE.
 #define CHECK_HIP(call) {\
     hipError_t hip_status = call;\
     if (hip_status != hipSuccess) {\
-        std::cout << "HIP failure: " << #call << " failed with 'status: " << hipGetErrorName(hip_status) << "' at " <<  __FILE__ << ":" << __LINE__ << std::endl;\
+        logger_.CriticalLog(MakeMsg("HIP failure: " + #call + " failed with 'status: " + STR(hipGetErrorName(hip_status)) + "' at " + __FILE__ + ":" + TOSTR(__LINE__)));\
         return ROCDEC_RUNTIME_ERROR;\
     }\
 }
@@ -53,7 +53,7 @@ THE SOFTWARE.
 #define CHECK_VAAPI(call) {\
     VAStatus va_status = call;\
     if (va_status != VA_STATUS_SUCCESS) {\
-        std::cout << "VAAPI failure: " << #call << " failed with status: " << std::hex << "0x" << va_status << std::dec << " = '" << vaErrorStr(va_status) << "' at " <<  __FILE__ << ":" << __LINE__ << std::endl;\
+        logger_.CriticalLog(MakeMsg("VAAPI failure: " + #call + " failed with 'status: " + TOSTR(va_status) + ": " + vaErrorStr(va_status) + "' at " + __FILE__ + ":" + TOSTR(__LINE__)));\
         return ROCDEC_RUNTIME_ERROR;\
     }\
 }
@@ -115,6 +115,8 @@ private:
     uint32_t num_slices_;
     VABufferID slice_data_buf_id_;
 
+    RocDecLogger logger_;
+
     bool IsCodecConfigSupported(int device_id, rocDecVideoCodec codec_type, rocDecVideoChromaFormat chroma_format, uint32_t bit_depth_minus8, rocDecVideoSurfaceFormat output_format);
     rocDecStatus CreateDecoderConfig();
     rocDecStatus CreateSurfaces();
@@ -151,6 +153,8 @@ private:
     VaContext(const VaContext&) = delete;
     VaContext& operator = (const VaContext) = delete;
     ~VaContext();
+
+    RocDecLogger logger_;
 
     rocDecStatus InitHIP(int device_id, hipDeviceProp_t& hip_dev_prop);
     rocDecStatus InitVAAPI(int va_ctx_idx, std::string drm_node);

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -813,19 +813,19 @@ int RocVideoDecoder::GetSEIMessage(RocdecSeiMessageInfo *pSEIMessageInfo) {
       RocdecSeiMessage *p_sei_msg_info = pSEIMessageInfo->sei_message;
       size_t total_SEI_buff_size = 0;
       if ((pSEIMessageInfo->picIdx < 0) || (pSEIMessageInfo->picIdx >= MAX_FRAME_NUM)) {
-          logger_.ErrorLog(MakeMsg("Invalid picture index for SEI message: " + TOSTR(pSEIMessageInfo->picIdx)));
+          ROCDEC_ERR("Invalid picture index for SEI message: " + TOSTR(pSEIMessageInfo->picIdx));
           return 0;
       }
       for (uint32_t i = 0; i < sei_num_mesages; i++) {
           total_SEI_buff_size += p_sei_msg_info[i].sei_message_size;
       }
       if (!curr_sei_message_ptr_) {
-          logger_.ErrorLog(MakeMsg("Out of Memory, Allocation failed for m_pCurrSEIMessage"));
+          ROCDEC_ERR("Out of Memory, Allocation failed for m_pCurrSEIMessage");
           return 0;
       }
       curr_sei_message_ptr_->sei_data = malloc(total_SEI_buff_size);
       if (!curr_sei_message_ptr_->sei_data) {
-          logger_.ErrorLog(MakeMsg("Out of Memory, Allocation failed for SEI Buffer"));
+          ROCDEC_ERR("Out of Memory, Allocation failed for SEI Buffer");
           return 0;
       }
       memcpy(curr_sei_message_ptr_->sei_data, pSEIMessageInfo->sei_data, total_SEI_buff_size);
@@ -855,7 +855,7 @@ int RocVideoDecoder::DecodeFrame(const uint8_t *data, size_t size, int pkt_flags
         packet.flags |= ROCDEC_PKT_ENDOFSTREAM;
     }
     if (rocDecParseVideoData(rocdec_parser_, &packet) != ROCDEC_SUCCESS) {
-        logger_.ErrorLog(MakeMsg("Error occurred in rocDecParseVideoData()."));
+        ROCDEC_ERR("Error occurred in rocDecParseVideoData().");
     }
     if (num_decoded_pics) {
         *num_decoded_pics = decoded_pic_cnt_;

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -813,19 +813,19 @@ int RocVideoDecoder::GetSEIMessage(RocdecSeiMessageInfo *pSEIMessageInfo) {
       RocdecSeiMessage *p_sei_msg_info = pSEIMessageInfo->sei_message;
       size_t total_SEI_buff_size = 0;
       if ((pSEIMessageInfo->picIdx < 0) || (pSEIMessageInfo->picIdx >= MAX_FRAME_NUM)) {
-          ROCDEC_ERR("Invalid picture index for SEI message: " + TOSTR(pSEIMessageInfo->picIdx));
+          logger_.ErrorLog(MakeMsg("Invalid picture index for SEI message: " + TOSTR(pSEIMessageInfo->picIdx)));
           return 0;
       }
       for (uint32_t i = 0; i < sei_num_mesages; i++) {
           total_SEI_buff_size += p_sei_msg_info[i].sei_message_size;
       }
       if (!curr_sei_message_ptr_) {
-          ROCDEC_ERR("Out of Memory, Allocation failed for m_pCurrSEIMessage");
+          logger_.ErrorLog(MakeMsg("Out of Memory, Allocation failed for m_pCurrSEIMessage"));
           return 0;
       }
       curr_sei_message_ptr_->sei_data = malloc(total_SEI_buff_size);
       if (!curr_sei_message_ptr_->sei_data) {
-          ROCDEC_ERR("Out of Memory, Allocation failed for SEI Buffer");
+          logger_.ErrorLog(MakeMsg("Out of Memory, Allocation failed for SEI Buffer"));
           return 0;
       }
       memcpy(curr_sei_message_ptr_->sei_data, pSEIMessageInfo->sei_data, total_SEI_buff_size);
@@ -855,7 +855,7 @@ int RocVideoDecoder::DecodeFrame(const uint8_t *data, size_t size, int pkt_flags
         packet.flags |= ROCDEC_PKT_ENDOFSTREAM;
     }
     if (rocDecParseVideoData(rocdec_parser_, &packet) != ROCDEC_SUCCESS) {
-        ROCDEC_ERR("Error occurred in rocDecParseVideoData().");
+        logger_.ErrorLog(MakeMsg("Error occurred in rocDecParseVideoData()."));
     }
     if (num_decoded_pics) {
         *num_decoded_pics = decoded_pic_cnt_;

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -39,7 +39,6 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 #include "rocdecode/rocdecode.h"
 #include "rocdecode/rocparser.h"
-#include "../../src/commons.h"
 
 /*!
  * \file
@@ -64,6 +63,9 @@ typedef enum OutputSurfaceMemoryType_enum {
     OUT_SURFACE_MEM_HOST_COPIED = 2,        /**<  decoded output will be copied to a separate host memory (the user doesn't need to call release) **/
     OUT_SURFACE_MEM_NOT_MAPPED  = 3         /**< <  decoded output is not available (interop won't be used): useful for decode only performance app*/
 } OutputSurfaceMemoryType;
+
+#define TOSTR(X) std::to_string(static_cast<int>(X))
+#define STR(X) std::string(X)
 
 #if DBGINFO
 #define ROCDEC_INFO(X) std::clog << "[INF] " << " {" << __func__ <<"} " << " " << X << std::endl;
@@ -153,7 +155,7 @@ private:
 
 #define CHECK_ZERO(str, value)              \
     if (value == 0) {                      \
-        logger_.ErrorLog(MakeMsg(STR(str) + " is 0."));         \
+        ROCDEC_ERR(STR(str) + " is 0.");    \
     }
 
 struct Rect {
@@ -526,6 +528,4 @@ class RocVideoDecoder {
         uint32_t extra_output_file_count_ = 0;
         std::thread::id decoder_session_id_; // Decoder session identifier. Used to gather session level stats.
         std::unordered_map<std::thread::id, double> session_overhead_; // Records session overhead of initialization+deinitialization time. Format is (thread id, duration)
-
-        RocDecLogger logger_;
 };

--- a/utils/rocvideodecode/roc_video_dec.h
+++ b/utils/rocvideodecode/roc_video_dec.h
@@ -39,6 +39,7 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 #include "rocdecode/rocdecode.h"
 #include "rocdecode/rocparser.h"
+#include "../../src/commons.h"
 
 /*!
  * \file
@@ -63,9 +64,6 @@ typedef enum OutputSurfaceMemoryType_enum {
     OUT_SURFACE_MEM_HOST_COPIED = 2,        /**<  decoded output will be copied to a separate host memory (the user doesn't need to call release) **/
     OUT_SURFACE_MEM_NOT_MAPPED  = 3         /**< <  decoded output is not available (interop won't be used): useful for decode only performance app*/
 } OutputSurfaceMemoryType;
-
-#define TOSTR(X) std::to_string(static_cast<int>(X))
-#define STR(X) std::string(X)
 
 #if DBGINFO
 #define ROCDEC_INFO(X) std::clog << "[INF] " << " {" << __func__ <<"} " << " " << X << std::endl;
@@ -155,7 +153,7 @@ private:
 
 #define CHECK_ZERO(str, value)              \
     if (value == 0) {                      \
-        ROCDEC_ERR(STR(str) + " is 0.");    \
+        logger_.ErrorLog(MakeMsg(STR(str) + " is 0."));         \
     }
 
 struct Rect {
@@ -528,4 +526,6 @@ class RocVideoDecoder {
         uint32_t extra_output_file_count_ = 0;
         std::thread::id decoder_session_id_; // Decoder session identifier. Used to gather session level stats.
         std::unordered_map<std::thread::id, double> session_overhead_; // Records session overhead of initialization+deinitialization time. Format is (thread id, duration)
+
+        RocDecLogger logger_;
 };


### PR DESCRIPTION
## Motivation

This PR added logging control to the core components.

## Technical Details

 - rocDecode core components can generate various logs during the decode session. The logs can be critical status reports, error reports, warnings, etc. Each log has a significance level associated to it. The level can be from critical (0) to debug info related (4). Lower value has greater importance. An internal logging level can be set to control the verbosity of logging output from each rocDecode component. If a log's level value is less than or equal to the logging level, the log is output. Otherwise, the log is not output.

 - The logging level can be set by the environment variable ROCDEC_LOG_LEVEL, or by calling the SetLogLevel method of the logger class. The default logging level is 0 (critical log only).

## Test Plan

Set ROCDEC_LOG_LEVEL to different values to check the output of logs of different levels. 

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
