### PR TITLE
Host decouple - samples and test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,6 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   # install rocdecode samples -- {ROCM_PATH}/share/rocdecode
   install(DIRECTORY cmake DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME} COMPONENT dev)
   install(DIRECTORY utils/rocvideodecode DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT dev)
-  install(DIRECTORY utils/ffmpegvideodecode DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT dev)
   install(FILES samples/videoDecode/CMakeLists.txt samples/videoDecode/README.md samples/videoDecode/videodecode.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/videoDecode COMPONENT dev)
   install(FILES samples/videoDecodeRaw/CMakeLists.txt samples/videoDecodeRaw/README.md samples/videoDecodeRaw/videodecoderaw.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/videoDecodeRaw COMPONENT dev)
   install(FILES samples/videoDecodeMem/CMakeLists.txt samples/videoDecodeMem/README.md samples/videoDecodeMem/videodecodemem.cpp DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/samples/videoDecodeMem COMPONENT dev)

--- a/samples/videoDecode/CMakeLists.txt
+++ b/samples/videoDecode/CMakeLists.txt
@@ -76,20 +76,24 @@ if(HIP_FOUND AND FFMPEG_FOUND AND rocdecode_FOUND AND Threads_FOUND AND rocprofi
                         ${AVFORMAT_INCLUDE_DIR})
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${FFMPEG_LIBRARIES})
     # rocdecode and utils
-    include_directories (${rocdecode_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR}/../../utils ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode)
+    include_directories (${rocdecode_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR}/../../utils ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocdecode::rocdecode)
     # threads
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} Threads::Threads)
     # rocprofiler-register
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
-    # rocdecode-host
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecode.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ffmpeg_video_dec.cpp)
+    # rocdecode
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecode.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp)
+    # Add rocdecode host utils if host library found
+    if(rocdecode-host_FOUND)
+      include_directories (${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode)
+      list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ffmpeg_video_dec.cpp)
+    endif()
     # sample app exe
     add_executable(${PROJECT_NAME} ${SOURCES})
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocdecode::rocdecode)
     if(rocdecode-host_FOUND)
-      # rocdecode-host
       include_directories(${rocdecode-host_INCLUDE_DIR})
       set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocdecode::rocdecode-host)
       target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_HOST_DECODE=1)

--- a/samples/videoDecode/videodecode.cpp
+++ b/samples/videoDecode/videodecode.cpp
@@ -39,10 +39,9 @@ THE SOFTWARE.
 #include "video_demuxer.h"
 #include "rocdecode/roc_bitstream_reader.h"
 #include "roc_video_dec.h"
-#include "ffmpeg_video_dec.h"
 #include "common.h"
 #if ENABLE_HOST_DECODE
-    #include "rocdecode/rocdecode_host.h"
+    #include "ffmpeg_video_dec.h"
 #endif
 
 //hardcoding for host based decoder creation if demux is not available

--- a/samples/videoDecodePerf/CMakeLists.txt
+++ b/samples/videoDecodePerf/CMakeLists.txt
@@ -76,7 +76,7 @@ if(HIP_FOUND AND FFMPEG_FOUND AND rocdecode_FOUND AND Threads_FOUND AND rocprofi
                       ${SWSCALE_INCLUDE_DIR} ${AVFORMAT_INCLUDE_DIR})
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${FFMPEG_LIBRARIES})
     # rocdecode and utils
-    include_directories (${rocdecode_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../../utils ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ ${CMAKE_CURRENT_SOURCE_DIR}/..)
+    include_directories (${rocdecode_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../../utils ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode ${CMAKE_CURRENT_SOURCE_DIR}/..)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocdecode::rocdecode)
     # threads
     set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -85,7 +85,11 @@ if(HIP_FOUND AND FFMPEG_FOUND AND rocdecode_FOUND AND Threads_FOUND AND rocprofi
     # rocprofiler-register
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
     # sample app exe
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodeperf.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ffmpeg_video_dec.cpp)
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodeperf.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp)
+    if(rocdecode-host_FOUND)
+      include_directories (${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode)
+      list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ffmpeg_video_dec.cpp)
+    endif()
     add_executable(${PROJECT_NAME} ${SOURCES})
     if(rocdecode-host_FOUND)
       # rocdecode-host

--- a/samples/videoDecodePerf/videodecodeperf.cpp
+++ b/samples/videoDecodePerf/videodecodeperf.cpp
@@ -35,10 +35,9 @@ THE SOFTWARE.
 #endif
 #include "video_demuxer.h"
 #include "roc_video_dec.h"
-#include "ffmpeg_video_dec.h"
 #include "common.h"
 #if ENABLE_HOST_DECODE
-    #include "rocdecode/rocdecode_host.h"
+    #include "ffmpeg_video_dec.h"
 #endif
 
 void DecProc(RocVideoDecoder *p_dec, VideoDemuxer *demuxer, int *pn_frame, int *pn_pic_dec, double *pn_fps, double *pn_fps_dec, int max_num_frames, OutputSurfaceMemoryType mem_type) {

--- a/samples/videoDecodePicFiles/CMakeLists.txt
+++ b/samples/videoDecodePicFiles/CMakeLists.txt
@@ -76,7 +76,7 @@ if(HIP_FOUND AND FFMPEG_FOUND AND rocdecode_FOUND AND Threads_FOUND AND rocprofi
                         ${AVFORMAT_INCLUDE_DIR})
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${FFMPEG_LIBRARIES})
     # rocdecode and utils
-    include_directories (${rocdecode_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR}/../../utils ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode)
+    include_directories (${rocdecode_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_SOURCE_DIR}/../../utils ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocdecode::rocdecode)
     # threads
     set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -84,7 +84,11 @@ if(HIP_FOUND AND FFMPEG_FOUND AND rocdecode_FOUND AND Threads_FOUND AND rocprofi
     # rocprofiler-register
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} rocprofiler-register::rocprofiler-register)
     # sample app exe
-    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodepicfiles.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ffmpeg_video_dec.cpp)
+    list(APPEND SOURCES ${PROJECT_SOURCE_DIR} videodecodepicfiles.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/rocvideodecode/roc_video_dec.cpp)
+    if(rocdecode-host_FOUND)
+      include_directories (${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode)
+      list(APPEND SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../../utils/ffmpegvideodecode/ffmpeg_video_dec.cpp)
+    endif()
     add_executable(${PROJECT_NAME} ${SOURCES})
     if(rocdecode-host_FOUND)
       # rocdecode-host

--- a/samples/videoDecodePicFiles/videodecodepicfiles.cpp
+++ b/samples/videoDecodePicFiles/videodecodepicfiles.cpp
@@ -34,10 +34,9 @@ THE SOFTWARE.
 #include "video_demuxer.h"
 #include "rocdecode/roc_bitstream_reader.h"
 #include "roc_video_dec.h"
-#include "ffmpeg_video_dec.h"
 #include "common.h"
 #if ENABLE_HOST_DECODE
-    #include "rocdecode/rocdecode_host.h"
+    #include "ffmpeg_video_dec.h"
 #endif
 
 void ShowHelpAndExit(const char *option = NULL) {

--- a/src/rocdecode-host/CMakeLists.txt
+++ b/src/rocdecode-host/CMakeLists.txt
@@ -104,7 +104,7 @@ if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_version.h
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rocdecode COMPONENT host)
   # TBD: NOTE the host utils are temp delivered with dev package, need to update downstream apps to move to host package
-  install(DIRECTORY ${PROJECT_SOURCE_DIR}/../../utils/ffmpegvideodecode DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT dev)
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/../../utils/ffmpegvideodecode DESTINATION ${CMAKE_INSTALL_DATADIR}/rocdecode/utils COMPONENT dev)
   
   # Cmake module config file configurations
   set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules/" CACHE INTERNAL "Default module path.")

--- a/src/rocdecode-host/CMakeLists.txt
+++ b/src/rocdecode-host/CMakeLists.txt
@@ -103,7 +103,8 @@ if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rocdecode COMPONENT host)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_version.h
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rocdecode COMPONENT host)
-  install(DIRECTORY ${PROJECT_SOURCE_DIR}/../../utils/ffmpegvideodecode DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT host)
+  # TBD: NOTE the host utils are temp delivered with dev package, need to update downstream apps to move to host package
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/../../utils/ffmpegvideodecode DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT dev)
   
   # Cmake module config file configurations
   set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules/" CACHE INTERNAL "Default module path.")

--- a/src/rocdecode-host/CMakeLists.txt
+++ b/src/rocdecode-host/CMakeLists.txt
@@ -103,6 +103,7 @@ if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
       DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rocdecode COMPONENT host)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_version.h
           DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rocdecode COMPONENT host)
+  install(DIRECTORY ${PROJECT_SOURCE_DIR}/../../utils/ffmpegvideodecode DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/utils COMPONENT host)
   
   # Cmake module config file configurations
   set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules/" CACHE INTERNAL "Default module path.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,7 +88,7 @@ else()
     message("-- \t${White}rocdecode-host_VERSION_MINOR -- ${rocdecode-host_VERSION_MINOR}${ColourReset}")
     message("-- \t${White}rocdecode-host_VERSION_PATCH -- ${rocdecode-host_VERSION_PATCH}${ColourReset}")
   else()
-    message("-- ${Yellow}${PROJECT_NAME} requires rocdecode-host. Install rocdecode-host before running CTests")
+    message("-- ${Yellow}${PROJECT_NAME} rocdecode-host is optional. Install rocdecode-host to run additional tests before running CTests")
   endif(rocdecode-host_FOUND)
 endif(BUILD_FROM_SOURCE)
 find_package(FFmpeg QUIET)
@@ -157,7 +157,7 @@ add_test(
             --test-command "rocdecodenegativetest"
 )
 
-if(FFMPEG_FOUND AND rocdecode-host_FOUND)
+if(FFMPEG_FOUND)
   message("-- ${Green}${PROJECT_NAME} FFmpeg found - rocdecode tests requiring FFmpeg added")
   # 6 - videoDecode HEVC
   add_test(
@@ -276,19 +276,23 @@ if(FFMPEG_FOUND AND rocdecode-host_FOUND)
             -i "${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" -resize 640x360 -of rgb
   )
 
-  # 15 - videoDecode Host backend
-  add_test(
-    NAME
-      video_decode-Host-Backend
-    COMMAND
-      "${CMAKE_CTEST_COMMAND}"
+  if(rocdecode-host_FOUND)
+    # 15 - videoDecode Host backend
+    add_test(
+      NAME
+        video_decode-Host-Backend
+      COMMAND
+        "${CMAKE_CTEST_COMMAND}"
             --build-and-test "${ROCM_PATH}/share/rocdecode/samples/videoDecode"
                               "${CMAKE_CURRENT_BINARY_DIR}/videoDecode-Host"
             --build-generator "${CMAKE_GENERATOR}"
             --test-command "videodecode"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
             -backend 1
-  )
+    )
+  else()
+    message("-- ${Yellow}${PROJECT_NAME} rocdecode-host NOT found. rocdecode tests requiring rocdecode-host excluded")
+  endif(rocdecode-host_FOUND)
 else()
-  message("-- ${Yellow}${PROJECT_NAME} FFmpeg and rocdecode-host NOT found. rocdecode tests requiring FFmpeg and rocdecode-host excluded")
-endif(FFMPEG_FOUND AND rocdecode-host_FOUND)
+  message("-- ${Yellow}${PROJECT_NAME} FFmpeg NOT found. rocdecode tests requiring FFmpeg excluded")
+endif(FFMPEG_FOUND)


### PR DESCRIPTION
## Motivation

Decouple host requirements from samples and tests

Fix for #672 

## Technical Details

Host library may not be built along with the core lib. This PR untangles host requirements from samples and tests to only use host libraries when found

## Test Plan

Current test package

## Test Result

Tests should pass with or without host li

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
