### PR TITLE
CMakeLists - Use ${CMAKE_CURRENT_SOURCE_DIR} instead of ${CMAKE_SOURCE_DIR} when referencing other files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,10 +174,10 @@ if(HIP_FOUND AND Libva_FOUND AND Libdrm_amdgpu_FOUND)
   endif()
 
   # local include files
-  include_directories(api src/rocdecode src/parser src/rocdecode/vaapi)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/api ${CMAKE_CURRENT_SOURCE_DIR}/src/rocdecode ${CMAKE_CURRENT_SOURCE_DIR}/src/parser ${CMAKE_CURRENT_SOURCE_DIR}/src/rocdecode/vaapi)
   # source files
-  file(GLOB_RECURSE SOURCES "./src/*.cpp")
-  list(FILTER SOURCES EXCLUDE REGEX "./src/rocdecode-host/*.*")
+  file(GLOB_RECURSE SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+  list(FILTER SOURCES EXCLUDE REGEX "${CMAKE_CURRENT_SOURCE_DIR}/src/rocdecode-host/*.*")
   # rocdecode.so
   add_library(${PROJECT_NAME} SHARED ${SOURCES})
 

--- a/src/rocdecode-host/CMakeLists.txt
+++ b/src/rocdecode-host/CMakeLists.txt
@@ -68,7 +68,7 @@ if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
   endif()
 
   # local include files
-  include_directories(api rocdecode-host ../src/rocdecode ../src/parser)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../api ${CMAKE_CURRENT_SOURCE_DIR}/../rocdecode-host ${CMAKE_CURRENT_SOURCE_DIR}/../rocdecode ${CMAKE_CURRENT_SOURCE_DIR}/../parser)
   # source files
   file(GLOB_RECURSE SOURCES "./*.cpp")
   # rocdecode-host.so
@@ -92,7 +92,7 @@ if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
   message("-- ${White}AMD ROCm ${PROJECT_NAME} -- Link Libraries: ${LINK_LIBRARY_LIST}${ColourReset}")
 
   # Generate BUILD_INFO
-  configure_file( ${CMAKE_SOURCE_DIR}/api/rocdecode-host_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/rocdecode-host_version.h @ONLY )
+  configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/../../api/rocdecode-host_version.h.in ${CMAKE_CURRENT_BINARY_DIR}/rocdecode-host_version.h @ONLY )
 
   # install rocdecode-host libs -- {ROCM_PATH}/lib
   set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
@@ -108,7 +108,7 @@ if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
   install(DIRECTORY ${PROJECT_SOURCE_DIR}/../../utils/ffmpegvideodecode DESTINATION ${CMAKE_INSTALL_DATADIR}/rocdecode/utils COMPONENT dev)
   
   # Cmake module config file configurations
-  set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules/" CACHE INTERNAL "Default module path.")
+  set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake_modules/" CACHE INTERNAL "Default module path.")
 
   # Export the package for use from the build-tree
   ## (this registers the build-tree with a global CMake-registry)

--- a/src/rocdecode-host/CMakeLists.txt
+++ b/src/rocdecode-host/CMakeLists.txt
@@ -68,9 +68,9 @@ if(HIP_FOUND AND Threads_FOUND AND FFMPEG_FOUND)
   endif()
 
   # local include files
-  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../api ${CMAKE_CURRENT_SOURCE_DIR}/../rocdecode-host ${CMAKE_CURRENT_SOURCE_DIR}/../rocdecode ${CMAKE_CURRENT_SOURCE_DIR}/../parser)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../api ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../rocdecode ${CMAKE_CURRENT_SOURCE_DIR}/../parser)
   # source files
-  file(GLOB_RECURSE SOURCES "./*.cpp")
+  file(GLOB_RECURSE SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
   # rocdecode-host.so
   add_library(${PROJECT_NAME} SHARED ${SOURCES})
 


### PR DESCRIPTION
## Motivation

Ensure rocDecode only refers to files within its own root when added as a subdirectory from an upper-level project.

## Technical Details

* Refer to other files with the `${CMAKE_CURRENT_SOURCE_DIR}` as a prefix instead of `${CMAKE_SOURCE_DIR}` or no prefix.
* Fixes #682 

## Test Plan

* Build `rocDecode` via `add_subdirectory(rocDecode)` in an upper-level project.

## Test Result

* No CMake configuration errors or compilation errors are observed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
