### PR TITLE
Fix for the incorrect MD5 results when user crop is enabled.

### DIFF
--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -388,11 +388,10 @@ int RocVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
     output_surface_info_.output_height = target_height_;
     output_surface_info_.output_pitch  = surface_stride_;
     output_surface_info_.output_vstride = (out_mem_type_ == OUT_SURFACE_MEM_DEV_INTERNAL) ? surface_vstride_ : videoDecodeCreateInfo.target_height;
-    if (!(crop_rect_.right && crop_rect_.bottom)) {
-        output_surface_info_.disp_rect = disp_rect_;
-    } else {
-        output_surface_info_.disp_rect = crop_rect_;
-    }
+    output_surface_info_.disp_rect.top = videoDecodeCreateInfo.display_rect.top;
+    output_surface_info_.disp_rect.bottom = videoDecodeCreateInfo.display_rect.bottom;
+    output_surface_info_.disp_rect.left = videoDecodeCreateInfo.display_rect.left;
+    output_surface_info_.disp_rect.right = videoDecodeCreateInfo.display_rect.right;
     output_surface_info_.chroma_height = chroma_height_;
     output_surface_info_.bit_depth = bitdepth_minus_8_ + 8;
     output_surface_info_.bytes_per_pixel = byte_per_pixel_;

--- a/utils/rocvideodecode/roc_video_dec.cpp
+++ b/utils/rocvideodecode/roc_video_dec.cpp
@@ -388,7 +388,11 @@ int RocVideoDecoder::HandleVideoSequence(RocdecVideoFormat *p_video_format) {
     output_surface_info_.output_height = target_height_;
     output_surface_info_.output_pitch  = surface_stride_;
     output_surface_info_.output_vstride = (out_mem_type_ == OUT_SURFACE_MEM_DEV_INTERNAL) ? surface_vstride_ : videoDecodeCreateInfo.target_height;
-    output_surface_info_.disp_rect = disp_rect_;
+    if (!(crop_rect_.right && crop_rect_.bottom)) {
+        output_surface_info_.disp_rect = disp_rect_;
+    } else {
+        output_surface_info_.disp_rect = crop_rect_;
+    }
     output_surface_info_.chroma_height = chroma_height_;
     output_surface_info_.bit_depth = bitdepth_minus_8_ + 8;
     output_surface_info_.bytes_per_pixel = byte_per_pixel_;
@@ -567,7 +571,11 @@ int RocVideoDecoder::ReconfigureDecoder(RocdecVideoFormat *p_video_format) {
     output_surface_info_.output_height = target_height_;
     output_surface_info_.output_pitch  = surface_stride_;
     output_surface_info_.output_vstride = (out_mem_type_ == OUT_SURFACE_MEM_DEV_INTERNAL) ? surface_vstride_ : target_height_;
-    output_surface_info_.disp_rect = disp_rect_;
+    if (!(crop_rect_.right && crop_rect_.bottom)) {
+        output_surface_info_.disp_rect = disp_rect_;
+    } else {
+        output_surface_info_.disp_rect = crop_rect_;
+    }
     output_surface_info_.chroma_height = chroma_height_;
     output_surface_info_.bit_depth = bitdepth_minus_8_ + 8;
     output_surface_info_.bytes_per_pixel = byte_per_pixel_;


### PR DESCRIPTION
## Motivation

This PR fixes the incorrect MD5 results when user crop is enabled.

## Technical Details

 - When the user cropping is enabled, the cropping rect needs to be sent to the output surface info struct, which is used by the MD5 calculation.

## Test Plan

- Run video decode sample app with cropping, output dump and MD5 enabled. Use an MD5 generation app to calculate the MD5 digest of the output YUV file, and compare to the MD5 output from the sample app.

## Test Result

- The two MD5 values should match.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
