### PR TITLE
rocdecdecode sample: Fixed the crash issue on AVC streams.

### DIFF
--- a/samples/rocdecDecode/rocdecdecode.cpp
+++ b/samples/rocdecDecode/rocdecdecode.cpp
@@ -65,7 +65,7 @@ __attribute__((visibility("hidden"))) inline void report_error(
                 << file_name << ":" << line)
      << ... << std::forward<Args>(args))
         << std::endl;
-    std::exit(-1);
+    std::exit(EXIT_FAILURE);
 }
 
 //hardcoding for this sample

--- a/samples/rocdecDecode/rocdecdecode.cpp
+++ b/samples/rocdecDecode/rocdecdecode.cpp
@@ -362,7 +362,7 @@ void create_decoder(DecoderInfo& dec_info) {
     // this will get changed in reconfigure when the sequence header is parsed from the stream to detect the actual video parameters
     create_info.chroma_format = rocDecVideoChromaFormat_420;
     create_info.output_format = rocDecVideoSurfaceFormat_NV12;
-    create_info.bit_depth_minus_8 = 2;
+    create_info.bit_depth_minus_8 = 0;
     create_info.num_output_surfaces = 1;
     CHECK(rocDecCreateDecoder(&dec_info.decoder, &create_info));
 }

--- a/samples/rocdecDecode/rocdecdecode.cpp
+++ b/samples/rocdecDecode/rocdecdecode.cpp
@@ -65,7 +65,7 @@ __attribute__((visibility("hidden"))) inline void report_error(
                 << file_name << ":" << line)
      << ... << std::forward<Args>(args))
         << std::endl;
-    std::abort();
+    std::exit(-1);
 }
 
 //hardcoding for this sample


### PR DESCRIPTION
## Motivation

This PR fixes the crash issue on AVC streams with rocdecdecode sample app.

## Technical Details

- We need to set bit depth to 8 when creating the initial decoder. This allows all codec types to be accommodated. Other bit depths can be supported in decoder reconfig later.
- Also Changed program stop from harsh abort to graceful exit, when a critical error occurs.

## Test Plan

run rocdecdecode sample on AVC streams.

## Test Result

The app should be able to decode the AVC streams.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
